### PR TITLE
Generate Git metadata in assembly

### DIFF
--- a/AssemblyVersion.cs
+++ b/AssemblyVersion.cs
@@ -1,2 +1,0 @@
-﻿// Copyright (c) Just Eat, 2017. All rights reserved.
-// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,7 @@
     <Company>Just Eat</Company>
     <Copyright>Copyright (c) Just Eat $([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <GenerateGitMetadata Condition=" '$(CI)' == 'true' and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/1516790?s=200</PackageIconUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
-    <Compile Include="$(MSBuildThisFileDirectory)AssemblyVersion.cs;$(MSBuildThisFileDirectory)CommonAssemblyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommonAssemblyInfo.cs" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup>
+    <CommitBranch Condition=" '$(CommitBranch)' == '' ">$(APPVEYOR_REPO_BRANCH)</CommitBranch>
     <CommitBranch Condition=" '$(CommitBranch)' == '' ">$(BUILD_SOURCEBRANCHNAME)</CommitBranch>
+    <CommitBranch Condition=" '$(CommitBranch)' == '' ">$(TRAVIS_BRANCH)</CommitBranch>
   </PropertyGroup>
   <Target Name="AddGitMetadaAssemblyAttributes"
           BeforeTargets="CoreGenerateAssemblyInfo"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,9 @@
 <Project>
   <PropertyGroup>
+    <CommitBranch Condition=" '$(CommitBranch)' == '' ">$(APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH)</CommitBranch>
     <CommitBranch Condition=" '$(CommitBranch)' == '' ">$(APPVEYOR_REPO_BRANCH)</CommitBranch>
     <CommitBranch Condition=" '$(CommitBranch)' == '' ">$(BUILD_SOURCEBRANCHNAME)</CommitBranch>
+    <CommitBranch Condition=" '$(CommitBranch)' == '' ">$(TRAVIS_PULL_REQUEST_BRANCH)</CommitBranch>
     <CommitBranch Condition=" '$(CommitBranch)' == '' ">$(TRAVIS_BRANCH)</CommitBranch>
   </PropertyGroup>
   <Target Name="AddGitMetadaAssemblyAttributes"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,2 +1,38 @@
 <Project>
+  <Target Name="AddGitMetadaAssemblyAttributes"
+          BeforeTargets="CoreGenerateAssemblyInfo"
+          Condition=" '$(GenerateGitMetadata)' == 'true' ">
+    <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(CommitHash)' == '' ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="CommitHash" />
+    </Exec>
+    <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(CommitBranch)' == '' ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="CommitBranch" />
+    </Exec>
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" $(CommitHash) != '' ">
+        <_Parameter1>CommitHash</_Parameter1>
+        <_Parameter2>$(CommitHash)</_Parameter2>
+      </AssemblyAttribute>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" $(CommitBranch) != '' ">
+        <_Parameter1>CommitBranch</_Parameter1>
+        <_Parameter2>$(CommitBranch)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+  <Target Name="GitMetadataAssemblyInfoCacheFileFix"
+          BeforeTargets="CreateGeneratedAssemblyInfoInputsCacheFile"
+          Condition=" '$(GenerateGitMetadata)' == 'true' ">
+    <ItemGroup>
+      <AssemblyAttribute Include="TemporaryAdditionalHashItem" Condition=" $(CommitHash) != '' or $(CommitBranch) != '' ">
+        <_Parameter1>$(CommitHash);$(CommitBranch)</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+  <Target Name="CleanupTemporaryAdditionalHashItem"
+          AfterTargets="CreateGeneratedAssemblyInfoInputsCacheFile;AddGitMetadaAssemblyAttributes"
+          Condition=" '$(GenerateGitMetadata)' == 'true' ">
+    <ItemGroup>
+      <AssemblyAttribute Remove="TemporaryAdditionalHashItem" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,7 @@
 <Project>
+  <PropertyGroup>
+    <CommitBranch Condition=" '$(CommitBranch)' == '' ">$(BUILD_SOURCEBRANCHNAME)</CommitBranch>
+  </PropertyGroup>
   <Target Name="AddGitMetadaAssemblyAttributes"
           BeforeTargets="CoreGenerateAssemblyInfo"
           Condition=" '$(GenerateGitMetadata)' == 'true' ">
@@ -9,6 +12,10 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="CommitBranch" />
     </Exec>
     <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+        <_Parameter1>BuildTimestamp</_Parameter1>
+        <_Parameter2>$([System.DateTime]::Now.ToString(yyyy-MM-ddTHH:mm:ssK))</_Parameter2>
+      </AssemblyAttribute>
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" $(CommitHash) != '' ">
         <_Parameter1>CommitHash</_Parameter1>
         <_Parameter2>$(CommitHash)</_Parameter2>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -14,7 +14,7 @@
     <ItemGroup>
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
         <_Parameter1>BuildTimestamp</_Parameter1>
-        <_Parameter2>$([System.DateTime]::Now.ToString(yyyy-MM-ddTHH:mm:ssK))</_Parameter2>
+        <_Parameter2>$([System.DateTime]::UtcNow.ToString(yyyy-MM-ddTHH:mm:ssK))</_Parameter2>
       </AssemblyAttribute>
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" $(CommitHash) != '' ">
         <_Parameter1>CommitHash</_Parameter1>

--- a/HttpClientInterception.sln
+++ b/HttpClientInterception.sln
@@ -12,7 +12,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
-		AssemblyVersion.cs = AssemblyVersion.cs
 		Build.ps1 = Build.ps1
 		build.sh = build.sh
 		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs


### PR DESCRIPTION
Add MSBuild targets to generate Git metadata in compiled assemblies.