### PR TITLE
Option to ignore query strings

### DIFF
--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -272,7 +272,7 @@ namespace JustEat.HttpClientInterception
 
             HttpInterceptionResponse interceptor = builder.Build();
 
-            string key = BuildKey(interceptor.Method, interceptor.RequestUri);
+            string key = BuildKey(interceptor.Method, interceptor.RequestUri, interceptor.IgnoreQuery);
             _mappings[key] = interceptor;
 
             return this;
@@ -296,11 +296,16 @@ namespace JustEat.HttpClientInterception
                 throw new ArgumentNullException(nameof(request));
             }
 
-            string key = BuildKey(request.Method, request.RequestUri);
+            string key = BuildKey(request.Method, request.RequestUri, ignoreQueryString: false);
 
             if (!_mappings.TryGetValue(key, out HttpInterceptionResponse options))
             {
-                return null;
+                string keyWithoutQueryString = BuildKey(request.Method, request.RequestUri, ignoreQueryString: true);
+
+                if (!_mappings.TryGetValue(keyWithoutQueryString, out options))
+                {
+                    return null;
+                }
             }
 
             if (options.OnIntercepted != null)
@@ -387,10 +392,23 @@ namespace JustEat.HttpClientInterception
         /// </summary>
         /// <param name="method">The HTTP method.</param>
         /// <param name="uri">The HTTP request URI.</param>
+        /// <param name="ignoreQueryString">If true create a key without any query string but with an extra string to disambiguate.</param>
         /// <returns>
         /// A <see cref="string"/> to use as the key for the interceptor registration.
         /// </returns>
-        private static string BuildKey(HttpMethod method, Uri uri) => $"{method.Method}:{uri}";
+        private static string BuildKey(HttpMethod method, Uri uri, bool ignoreQueryString = false)
+        {
+            if (ignoreQueryString)
+            {
+                var uriWithoutQueryString = uri == null ? null : new UriBuilder(uri) { Query = string.Empty }.Uri;
+
+                return $"{method.Method}:IGNOREQUERY:{uriWithoutQueryString}";
+            }
+            else
+            {
+                return $"{method.Method}:{uri}";
+            }
+        }
 
         private sealed class OptionsScope : IDisposable
         {

--- a/src/HttpClientInterception/HttpInterceptionResponse.cs
+++ b/src/HttpClientInterception/HttpInterceptionResponse.cs
@@ -28,6 +28,8 @@ namespace JustEat.HttpClientInterception
 
         internal IEnumerable<KeyValuePair<string, IEnumerable<string>>> ContentHeaders { get; set; }
 
+        internal bool IgnoreQuery { get; set; }
+
         internal IEnumerable<KeyValuePair<string, IEnumerable<string>>> ResponseHeaders { get; set; }
 
         internal Func<HttpRequestMessage, Task> OnIntercepted { get; set; }

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
@@ -40,6 +40,7 @@ namespace JustEat.HttpClientInterception
         private UriBuilder _uriBuilder = new UriBuilder();
 
         private Version _version;
+        private bool _ignoreQuery;
 
         /// <summary>
         /// Sets the HTTP method to intercept a request for.
@@ -119,6 +120,17 @@ namespace JustEat.HttpClientInterception
         public HttpRequestInterceptionBuilder ForQuery(string query)
         {
             _uriBuilder.Query = query;
+            return this;
+        }
+
+        /// <summary>
+        /// If true query strings will be ignored when testing request URIs.
+        /// </summary>
+        /// <param name="ignoreQuery">Whether to ignore query strings or not; defaults to true.</param>
+        /// <returns>The current <see cref="HttpRequestInterceptionBuilder"/>.</returns>
+        public HttpRequestInterceptionBuilder IgnoringQuery(bool ignoreQuery = true)
+        {
+            _ignoreQuery = ignoreQuery;
             return this;
         }
 
@@ -508,6 +520,7 @@ namespace JustEat.HttpClientInterception
                 ContentFactory = _contentFactory ?? EmptyContentFactory,
                 ContentStream = _contentStream,
                 ContentMediaType = _mediaType,
+                IgnoreQuery = _ignoreQuery,
                 Method = _method,
                 OnIntercepted = _onIntercepted,
                 ReasonPhrase = _reasonPhrase,

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
@@ -21,7 +21,7 @@ namespace JustEat.HttpClientInterception
         {
             // Arrange
             var options = new HttpClientInterceptorOptions();
-            var request = new HttpRequestMessage();
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://google.com");
 
             // Act
             HttpResponseMessage actual = await options.GetResponseAsync(request);

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -558,6 +558,42 @@ namespace JustEat.HttpClientInterception
         }
 
         [Fact]
+        public static async Task Register_Builds_Ignore_Query_Key()
+        {
+            // Arrange
+            var options = new HttpClientInterceptorOptions();
+
+            HttpRequestInterceptionBuilder builder = new HttpRequestInterceptionBuilder()
+                .ForHost("something.com")
+                .IgnoringQuery();
+
+            // Act
+            options.Register(builder);
+
+            // Assert
+            (await HttpAssert.GetAsync(options, "http://something.com?query=1234")).ShouldBeEmpty();
+        }
+
+        [Fact]
+        public static async Task Register_Builds_Without_Ignore_Query_Key()
+        {
+            // Arrange
+            var options = new HttpClientInterceptorOptions();
+
+            HttpRequestInterceptionBuilder builder = new HttpRequestInterceptionBuilder()
+                .ForHost("something.com")
+                .IgnoringQuery()
+                .IgnoringQuery(false);
+
+            // Act
+            options.Register(builder);
+
+            // Assert
+            await Assert.ThrowsAsync<HttpRequestException>(() =>
+                HttpAssert.GetAsync(options, "http://something.com?query=1234"));
+        }
+
+        [Fact]
         public static async Task Register_Builds_Uri_From_UriBuilder()
         {
             // Arrange


### PR DESCRIPTION
Sometimes query strings can get pretty long and you also need to think about the order of parameters.  It would be easier if you could just register an interceptor and tell it not to disregard the query string for this registration entirely.

I.e. we register this mapping in a different dictionary and test each request against both sets of mappings, removing the query string for the "ignore query string" mapping.

Note this PR isn't tested or complete (no tests and I think a bit of extra plumbing too).  I wanted to check what you thought of it first.