### PR TITLE
Add overloads for multiple registrations

### DIFF
--- a/src/HttpClientInterception/HttpClientInterceptorOptionsExtensions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptionsExtensions.cs
@@ -262,5 +262,56 @@ namespace JustEat.HttpClientInterception
 
             return options.Deregister(HttpMethod.Get, new Uri(uriString));
         }
+
+        /// <summary>
+        /// Registers one or more HTTP request interceptions, replacing any existing registrations.
+        /// </summary>
+        /// <param name="options">The <see cref="HttpClientInterceptorOptions"/> to set up.</param>
+        /// <param name="collection">A collection of <see cref="HttpRequestInterceptionBuilder"/> instances to use to create the registration(s).</param>
+        /// <returns>
+        /// The current <see cref="HttpClientInterceptorOptions"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="options"/> or <paramref name="collection"/> is <see langword="null"/>.
+        /// </exception>
+        public static HttpClientInterceptorOptions Register(
+            this HttpClientInterceptorOptions options,
+            IEnumerable<HttpRequestInterceptionBuilder> collection)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            foreach (var builder in collection)
+            {
+                options.Register(builder);
+            }
+
+            return options;
+        }
+
+        /// <summary>
+        /// Registers one or more HTTP request interceptions, replacing any existing registrations.
+        /// </summary>
+        /// <param name="options">The <see cref="HttpClientInterceptorOptions"/> to set up.</param>
+        /// <param name="collection">An array of one or more <see cref="HttpRequestInterceptionBuilder"/> instances to use to create the registration(s).</param>
+        /// <returns>
+        /// The current <see cref="HttpClientInterceptorOptions"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="options"/> or <paramref name="collection"/> is <see langword="null"/>.
+        /// </exception>
+        public static HttpClientInterceptorOptions Register(
+            this HttpClientInterceptorOptions options,
+            params HttpRequestInterceptionBuilder[] collection)
+        {
+            return options.Register(collection as IEnumerable<HttpRequestInterceptionBuilder>);
+        }
     }
 }

--- a/tests/HttpClientInterception.Tests/Examples.cs
+++ b/tests/HttpClientInterception.Tests/Examples.cs
@@ -442,5 +442,43 @@ namespace JustEat.HttpClientInterception
             actual.Login.ShouldBe("justeat");
             actual.Url.ShouldBe("https://api.github.com/orgs/justeat");
         }
+
+        [Fact]
+        public static async Task Use_Multiple_Registrations()
+        {
+            // Arrange
+            var justEat = new HttpRequestInterceptionBuilder()
+                .ForHttps()
+                .ForHost("api.github.com")
+                .ForPath("orgs/justeat")
+                .WithJsonContent(new { id = 1516790, login = "justeat", url = "https://api.github.com/orgs/justeat" });
+
+            var dotnet = new HttpRequestInterceptionBuilder()
+                .ForHttps()
+                .ForHost("api.github.com")
+                .ForPath("orgs/dotnet")
+                .WithJsonContent(new { id = 9141961, login = "dotnet", url = "https://api.github.com/orgs/dotnet" });
+
+            var options = new HttpClientInterceptorOptions()
+                .Register(justEat, dotnet);
+
+            var service = RestService.For<IGitHub>(options.CreateHttpClient("https://api.github.com"));
+
+            // Act
+            Organization justEatOrg = await service.GetOrganizationAsync("justeat");
+            Organization dotnetOrg = await service.GetOrganizationAsync("dotnet");
+
+            // Assert
+            justEatOrg.ShouldNotBeNull();
+            justEatOrg.Id.ShouldBe("1516790");
+            justEatOrg.Login.ShouldBe("justeat");
+            justEatOrg.Url.ShouldBe("https://api.github.com/orgs/justeat");
+
+            // Assert
+            dotnetOrg.ShouldNotBeNull();
+            dotnetOrg.Id.ShouldBe("9141961");
+            dotnetOrg.Login.ShouldBe("dotnet");
+            dotnetOrg.Url.ShouldBe("https://api.github.com/orgs/dotnet");
+        }
     }
 }

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsExtensionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsExtensionsTests.cs
@@ -138,6 +138,120 @@ namespace JustEat.HttpClientInterception
             Assert.Throws<ArgumentNullException>("options", () => options.CreateHttpClient(baseAddress));
         }
 
+        [Fact]
+        public static void Register_For_Collection_Throws_If_Options_Is_Null()
+        {
+            // Arrange
+            var baseAddress = new Uri("https://google.com");
+
+            HttpClientInterceptorOptions options = null;
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("options", () => options.Register(new List<HttpRequestInterceptionBuilder>()));
+        }
+
+        [Fact]
+        public static void Register_For_Collection_Throws_If_Collection_Is_Null()
+        {
+            // Arrange
+            var baseAddress = new Uri("https://google.com");
+
+            var options = new HttpClientInterceptorOptions();
+            IEnumerable<HttpRequestInterceptionBuilder> collection = null;
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("collection", () => options.Register(collection));
+        }
+
+        [Fact]
+        public static async Task Register_For_Collection_Registers_Interceptions()
+        {
+            // Arrange
+            var builder1 = new HttpRequestInterceptionBuilder()
+                .ForGet()
+                .ForUrl("https://google.com/")
+                .WithContent("foo");
+
+            var builder2 = new HttpRequestInterceptionBuilder()
+                .ForGet()
+                .ForUrl("https://bing.com/")
+                .WithContent("bar");
+
+            var options = new HttpClientInterceptorOptions()
+                .Register(new[] { builder1, builder2 });
+
+            string actual1;
+            string actual2;
+
+            // Act
+            using (var httpClient = options.CreateHttpClient())
+            {
+                actual1 = await httpClient.GetStringAsync("https://google.com/");
+                actual2 = await httpClient.GetStringAsync("https://bing.com/");
+            }
+
+            // Assert
+            actual1.ShouldBe("foo");
+            actual2.ShouldBe("bar");
+        }
+
+        [Fact]
+        public static void Register_For_Array_Throws_If_Options_Is_Null()
+        {
+            // Arrange
+            var baseAddress = new Uri("https://google.com");
+
+            HttpClientInterceptorOptions options = null;
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("options", () => options.Register(Array.Empty<HttpRequestInterceptionBuilder>()));
+        }
+
+        [Fact]
+        public static void Register_For_Array_Throws_If_Collection_Is_Null()
+        {
+            // Arrange
+            var baseAddress = new Uri("https://google.com");
+
+            var options = new HttpClientInterceptorOptions();
+            HttpRequestInterceptionBuilder[] collection = null;
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("collection", () => options.Register(collection));
+        }
+
+        [Fact]
+        public static async Task Register_For_Array_Registers_Interceptions()
+        {
+            // Arrange
+            var builder1 = new HttpRequestInterceptionBuilder()
+                .ForGet()
+                .ForUrl("https://google.com/")
+                .WithContent("foo");
+
+            var builder2 = new HttpRequestInterceptionBuilder()
+                .ForGet()
+                .ForUrl("https://bing.com/")
+                .WithContent("bar");
+
+            var options = new HttpClientInterceptorOptions()
+                .Register(builder1, builder2);
+
+            string actual1;
+            string actual2;
+
+            // Act
+            using (var httpClient = options.CreateHttpClient())
+            {
+                actual1 = await httpClient.GetStringAsync("https://google.com/");
+                actual2 = await httpClient.GetStringAsync("https://bing.com/");
+            }
+
+            // Assert
+            actual1.ShouldBe("foo");
+            actual2.ShouldBe("bar");
+        }
+
         private sealed class CustomObject
         {
             internal enum Color


### PR DESCRIPTION
Add convenience overload methods for registering multiple interceptions at once to resolve #11.

/cc @gareththackeray

