### PR TITLE
Support cloning builders

### DIFF
--- a/tests/HttpClientInterception.Tests/Examples.cs
+++ b/tests/HttpClientInterception.Tests/Examples.cs
@@ -453,9 +453,8 @@ namespace JustEat.HttpClientInterception
                 .ForPath("orgs/justeat")
                 .WithJsonContent(new { id = 1516790, login = "justeat", url = "https://api.github.com/orgs/justeat" });
 
-            var dotnet = new HttpRequestInterceptionBuilder()
-                .ForHttps()
-                .ForHost("api.github.com")
+            var dotnet = justEat
+                .Clone()
                 .ForPath("orgs/dotnet")
                 .WithJsonContent(new { id = 9141961, login = "dotnet", url = "https://api.github.com/orgs/dotnet" });
 

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -933,6 +933,55 @@ namespace JustEat.HttpClientInterception
             wasDelegateInvoked.ShouldBeFalse();
         }
 
+        [Fact]
+        public static void Can_Clone_New_Builder()
+        {
+            // Arrange
+            var original = new HttpRequestInterceptionBuilder();
+
+            // Act
+            var clone = original.Clone();
+
+            // Assert
+            clone.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public static async Task Can_Clone_Used_Builder()
+        {
+            // Arrange
+            var original = new HttpRequestInterceptionBuilder()
+                .ForHttps()
+                .ForGet()
+                .ForHost("www.just-eat.co.uk")
+                .ForPath("/")
+                .WithContentHeader("content-type", "text/html")
+                .WithResponseHeader("cache-control", "private")
+                .WithContent("Just Eat");
+
+            // Act
+            var cloned = original.Clone();
+
+            // Assert
+            cloned.ShouldNotBeNull();
+
+            // Arrange
+            cloned
+                .ForHost("www.just-eat.ie")
+                .WithContentHeader("content-type", "text/plain");
+
+            var options = new HttpClientInterceptorOptions()
+                .Register(original, cloned);
+
+            // Act
+            string result1 = await HttpAssert.GetAsync(options, "https://www.just-eat.co.uk/");
+            string result2 = await HttpAssert.GetAsync(options, "https://www.just-eat.ie/");
+
+            // Assert
+            result1.ShouldBe("Just Eat");
+            result1.ShouldBe(result2);
+        }
+
         private sealed class CustomObject
         {
             internal enum Color


### PR DESCRIPTION
Support cloning of `HttpRequestInterceptionBuilder` to enable quickly setting up almost identical builders for multiple intercepted requests.

Relates to #12.