### PR TITLE
Add Source Link

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CommonAssemblyInfo.cs" />
     <PackageReference Include="OpenCover" Version="4.6.519" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="3.1.2" PrivateAssets="All" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
Add Source Link support.

Source file embedding is not used as that requires portable PDBs, but using those precludes OpenCover code coverage metrics.

Relates to #15.

