### PR TITLE
Test for Linux and OS X in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: required
 dist: trusty
 
+os:
+  - linux
+  - osx
+
 env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true


### PR DESCRIPTION
Update the YAML for Travis CI to test for Linux and OS X (as a proxy for macOS).
