### PR TITLE
Support matching any host and providing fallback responses

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 os: Visual Studio 2017
-version: 1.1.1.{build}
+version: 1.2.0.{build}
 
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/samples/SampleApp.Tests/SampleApp.Tests.csproj
+++ b/samples/SampleApp.Tests/SampleApp.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>latest</LangVersion>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
@@ -9,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <LangVersion>latest</LangVersion>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -398,6 +398,12 @@ namespace JustEat.HttpClientInterception
                 keyPrefix = "IGNOREHOST;";
             }
 
+            if (interceptor.IgnorePath)
+            {
+                builderForKey.Path = string.Empty;
+                keyPrefix += "IGNOREPATH;";
+            }
+
             if (interceptor.IgnoreQuery)
             {
                 builderForKey.Query = string.Empty;

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -55,6 +55,12 @@ namespace JustEat.HttpClientInterception
         }
 
         /// <summary>
+        /// Gets or sets an optional delegate to invoke when an HTTP request does not match an existing
+        /// registration, which optionally returns an <see cref="HttpResponseMessage"/> to use.
+        /// </summary>
+        public Func<HttpRequestMessage, Task<HttpResponseMessage>> OnMissingRegistration { get; set; }
+
+        /// <summary>
         /// Gets or sets an optional delegate to invoke when an HTTP request is sent.
         /// </summary>
         public Func<HttpRequestMessage, Task> OnSend { get; set; }

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -384,7 +384,9 @@ namespace JustEat.HttpClientInterception
         {
             if (interceptor.UserMatcher != null)
             {
-                return $"CUSTOM:{interceptor.UserMatcher.GetHashCode().ToString(CultureInfo.InvariantCulture)}";
+                // Use the internal matcher's hash code as UserMatcher (a delegate)
+                // will always return the hash code. See https://stackoverflow.com/q/6624151/1064169
+                return $"CUSTOM:{interceptor.InternalMatcher.GetHashCode().ToString(CultureInfo.InvariantCulture)}";
             }
 
             var builderForKey = new UriBuilder(interceptor.RequestUri);

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -421,6 +421,8 @@ namespace JustEat.HttpClientInterception
         private bool TryGetResponse(HttpRequestMessage request, out HttpInterceptionResponse response)
         {
             response = _mappings.Values
+                .OrderByDescending((p) => p.Priority.HasValue)
+                .ThenBy((p) => p.Priority)
                 .Where((p) => p.InternalMatcher.IsMatch(request))
                 .FirstOrDefault();
 

--- a/src/HttpClientInterception/HttpInterceptionResponse.cs
+++ b/src/HttpClientInterception/HttpInterceptionResponse.cs
@@ -28,6 +28,8 @@ namespace JustEat.HttpClientInterception
 
         internal IEnumerable<KeyValuePair<string, IEnumerable<string>>> ContentHeaders { get; set; }
 
+        internal bool IgnoreHost { get; set; }
+
         internal bool IgnoreQuery { get; set; }
 
         internal IEnumerable<KeyValuePair<string, IEnumerable<string>>> ResponseHeaders { get; set; }

--- a/src/HttpClientInterception/HttpInterceptionResponse.cs
+++ b/src/HttpClientInterception/HttpInterceptionResponse.cs
@@ -12,6 +12,10 @@ namespace JustEat.HttpClientInterception
 {
     internal sealed class HttpInterceptionResponse
     {
+        internal Predicate<HttpRequestMessage> UserMatcher { get; set; }
+
+        internal Matching.RequestMatcher InternalMatcher { get; set; }
+
         internal HttpMethod Method { get; set; }
 
         internal string ReasonPhrase { get; set; }

--- a/src/HttpClientInterception/HttpInterceptionResponse.cs
+++ b/src/HttpClientInterception/HttpInterceptionResponse.cs
@@ -18,6 +18,8 @@ namespace JustEat.HttpClientInterception
 
         internal HttpMethod Method { get; set; }
 
+        internal int? Priority { get; set; }
+
         internal string ReasonPhrase { get; set; }
 
         internal Uri RequestUri { get; set; }

--- a/src/HttpClientInterception/HttpInterceptionResponse.cs
+++ b/src/HttpClientInterception/HttpInterceptionResponse.cs
@@ -36,6 +36,8 @@ namespace JustEat.HttpClientInterception
 
         internal bool IgnoreHost { get; set; }
 
+        internal bool IgnorePath { get; set; }
+
         internal bool IgnoreQuery { get; set; }
 
         internal IEnumerable<KeyValuePair<string, IEnumerable<string>>> ResponseHeaders { get; set; }

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
@@ -45,6 +45,8 @@ namespace JustEat.HttpClientInterception
 
         private bool _ignoreHost;
 
+        private bool _ignorePath;
+
         private bool _ignoreQuery;
 
         private int? _priority;
@@ -159,6 +161,17 @@ namespace JustEat.HttpClientInterception
         public HttpRequestInterceptionBuilder ForQuery(string query)
         {
             _uriBuilder.Query = query;
+            return this;
+        }
+
+        /// <summary>
+        /// If true URI paths will be ignored when testing request URIs.
+        /// </summary>
+        /// <param name="ignorePath">Whether to ignore paths or not; defaults to true.</param>
+        /// <returns>The current <see cref="HttpRequestInterceptionBuilder"/>.</returns>
+        public HttpRequestInterceptionBuilder IgnoringPath(bool ignorePath = true)
+        {
+            _ignorePath = ignorePath;
             return this;
         }
 
@@ -617,6 +630,7 @@ namespace JustEat.HttpClientInterception
                 ContentStream = _contentStream,
                 ContentMediaType = _mediaType,
                 IgnoreHost = _ignoreHost,
+                IgnorePath = _ignorePath,
                 IgnoreQuery = _ignoreQuery,
                 Method = _method,
                 OnIntercepted = _onIntercepted,

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
@@ -50,14 +50,17 @@ namespace JustEat.HttpClientInterception
         /// <summary>
         /// Configures the builder to match any request that meets the criteria defined by the specified predicate.
         /// </summary>
-        /// <param name="predicate">A delgate to a method which returns <see langword="true"/> if the request is considered a match.</param>
+        /// <param name="predicate">
+        /// A delegate to a method which returns <see langword="true"/> if the
+        /// request is considered a match; otherwise <see langword="false"/>.
+        /// </param>
         /// <returns>
         /// The current <see cref="HttpRequestInterceptionBuilder"/>.
         /// </returns>
         /// <remarks>
         /// Pass a value of <see langword="null"/> to remove a previously-registered custom request matching predicate.
         /// </remarks>
-        public HttpRequestInterceptionBuilder ForRequest(Predicate<HttpRequestMessage> predicate)
+        public HttpRequestInterceptionBuilder For(Predicate<HttpRequestMessage> predicate)
         {
             _requestMatcher = predicate;
             return this;

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
@@ -47,6 +47,8 @@ namespace JustEat.HttpClientInterception
 
         private bool _ignoreQuery;
 
+        private int? _priority;
+
         /// <summary>
         /// Configures the builder to match any request that meets the criteria defined by the specified predicate.
         /// </summary>
@@ -583,6 +585,30 @@ namespace JustEat.HttpClientInterception
             return this;
         }
 
+        /// <summary>
+        /// Sets the priority for matching against HTTP requests.
+        /// </summary>
+        /// <param name="priority">The priority of the HTTP interception.</param>
+        /// <returns>
+        /// The current <see cref="HttpRequestInterceptionBuilder"/>.
+        /// </returns>
+        /// <remarks>
+        /// The priority is used to establish a hierarchy for matching of intercepted
+        /// HTTP requests, particularly when <see cref="For"/> is used. This allows
+        /// registered requests to establish an order of precedence when an HTTP request
+        /// could match against multiple predicates, where the matching predicate with
+        /// the lowest value for <paramref name="priority"/> dictates the HTTP response
+        /// that is used for the intercepted request.
+        /// <para />
+        /// By default an interception has no priority, so the first arbitrary registration
+        /// that matches which does not have a priority will be used to provide the response.
+        /// </remarks>
+        public HttpRequestInterceptionBuilder HavingPriority(int? priority)
+        {
+            _priority = priority;
+            return this;
+        }
+
         internal HttpInterceptionResponse Build()
         {
             var response = new HttpInterceptionResponse()
@@ -594,6 +620,7 @@ namespace JustEat.HttpClientInterception
                 IgnoreQuery = _ignoreQuery,
                 Method = _method,
                 OnIntercepted = _onIntercepted,
+                Priority = _priority,
                 ReasonPhrase = _reasonPhrase,
                 RequestUri = _uriBuilder.Uri,
                 StatusCode = _statusCode,

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
@@ -33,6 +33,8 @@ namespace JustEat.HttpClientInterception
 
         private Func<HttpRequestMessage, Task<bool>> _onIntercepted;
 
+        private Predicate<HttpRequestMessage> _requestMatcher;
+
         private string _reasonPhrase;
 
         private HttpStatusCode _statusCode = HttpStatusCode.OK;
@@ -44,6 +46,22 @@ namespace JustEat.HttpClientInterception
         private bool _ignoreHost;
 
         private bool _ignoreQuery;
+
+        /// <summary>
+        /// Configures the builder to match any request that meets the criteria defined by the specified predicate.
+        /// </summary>
+        /// <param name="predicate">A delgate to a method which returns <see langword="true"/> if the request is considered a match.</param>
+        /// <returns>
+        /// The current <see cref="HttpRequestInterceptionBuilder"/>.
+        /// </returns>
+        /// <remarks>
+        /// Pass a value of <see langword="null"/> to remove a previously-registered custom request matching predicate.
+        /// </remarks>
+        public HttpRequestInterceptionBuilder ForRequest(Predicate<HttpRequestMessage> predicate)
+        {
+            _requestMatcher = predicate;
+            return this;
+        }
 
         /// <summary>
         /// Configures the builder to match any host name.
@@ -576,6 +594,7 @@ namespace JustEat.HttpClientInterception
                 ReasonPhrase = _reasonPhrase,
                 RequestUri = _uriBuilder.Uri,
                 StatusCode = _statusCode,
+                UserMatcher = _requestMatcher,
                 Version = _version,
             };
 

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
@@ -40,7 +40,22 @@ namespace JustEat.HttpClientInterception
         private UriBuilder _uriBuilder = new UriBuilder();
 
         private Version _version;
+
+        private bool _ignoreHost;
+
         private bool _ignoreQuery;
+
+        /// <summary>
+        /// Configures the builder to match any host name.
+        /// </summary>
+        /// <returns>
+        /// The current <see cref="HttpRequestInterceptionBuilder"/>.
+        /// </returns>
+        public HttpRequestInterceptionBuilder ForAnyHost()
+        {
+            _ignoreHost = true;
+            return this;
+        }
 
         /// <summary>
         /// Sets the HTTP method to intercept a request for.
@@ -81,6 +96,7 @@ namespace JustEat.HttpClientInterception
         public HttpRequestInterceptionBuilder ForHost(string host)
         {
             _uriBuilder.Host = host;
+            _ignoreHost = false;
             return this;
         }
 
@@ -144,6 +160,7 @@ namespace JustEat.HttpClientInterception
         public HttpRequestInterceptionBuilder ForUri(Uri uri)
         {
             _uriBuilder = new UriBuilder(uri);
+            _ignoreHost = false;
             return this;
         }
 
@@ -160,6 +177,7 @@ namespace JustEat.HttpClientInterception
         public HttpRequestInterceptionBuilder ForUri(UriBuilder uriBuilder)
         {
             _uriBuilder = uriBuilder ?? throw new ArgumentNullException(nameof(uriBuilder));
+            _ignoreHost = false;
             return this;
         }
 
@@ -551,6 +569,7 @@ namespace JustEat.HttpClientInterception
                 ContentFactory = _contentFactory ?? EmptyContentFactory,
                 ContentStream = _contentStream,
                 ContentMediaType = _mediaType,
+                IgnoreHost = _ignoreHost,
                 IgnoreQuery = _ignoreQuery,
                 Method = _method,
                 OnIntercepted = _onIntercepted,

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilderExtensions.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilderExtensions.cs
@@ -212,5 +212,23 @@ namespace JustEat.HttpClientInterception
 
             return builder.ForUri(new Uri(uriString));
         }
+
+        /// <summary>
+        /// A convenience method that can be used to signify the start of request method calls for fluent registrations.
+        /// </summary>
+        /// <param name="builder">The <see cref="HttpRequestInterceptionBuilder"/> to use.</param>
+        /// <returns>
+        /// The value specified by <paramref name="builder"/>.
+        /// </returns>
+        public static HttpRequestInterceptionBuilder Requests(this HttpRequestInterceptionBuilder builder) => builder;
+
+        /// <summary>
+        /// A convenience method that can be used to signify the start of response method calls for fluent registrations.
+        /// </summary>
+        /// <param name="builder">The <see cref="HttpRequestInterceptionBuilder"/> to use.</param>
+        /// <returns>
+        /// The value specified by <paramref name="builder"/>.
+        /// </returns>
+        public static HttpRequestInterceptionBuilder Responds(this HttpRequestInterceptionBuilder builder) => builder;
     }
 }

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilderExtensions.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilderExtensions.cs
@@ -230,5 +230,28 @@ namespace JustEat.HttpClientInterception
         /// The value specified by <paramref name="builder"/>.
         /// </returns>
         public static HttpRequestInterceptionBuilder Responds(this HttpRequestInterceptionBuilder builder) => builder;
+
+        /// <summary>
+        /// Registers the builder with the specified <see cref="HttpClientInterceptorOptions"/> instance.
+        /// </summary>
+        /// <param name="builder">The <see cref="HttpRequestInterceptionBuilder"/> to use to create the registration.</param>
+        /// <param name="options">The <see cref="HttpClientInterceptorOptions"/> to register the builder with.</param>
+        /// <returns>
+        /// The current <see cref="HttpRequestInterceptionBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public static HttpRequestInterceptionBuilder RegisterWith(this HttpRequestInterceptionBuilder builder, HttpClientInterceptorOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            options.Register(builder);
+
+            return builder;
+        }
     }
 }

--- a/src/HttpClientInterception/InterceptingHttpMessageHandler.cs
+++ b/src/HttpClientInterception/InterceptingHttpMessageHandler.cs
@@ -56,6 +56,11 @@ namespace JustEat.HttpClientInterception
 
             HttpResponseMessage response = await _options.GetResponseAsync(request);
 
+            if (response == null && _options.OnMissingRegistration != null)
+            {
+                response = await _options.OnMissingRegistration(request);
+            }
+
             if (response != null)
             {
                 return response;

--- a/src/HttpClientInterception/Matching/DelegatingMatcher.cs
+++ b/src/HttpClientInterception/Matching/DelegatingMatcher.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Just Eat, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Http;
+
+namespace JustEat.HttpClientInterception.Matching
+{
+    /// <summary>
+    /// A class representing an implementation of <see cref="RequestMatcher"/> that
+    /// delegates to a user-provided delegate. This class cannot be inherited.
+    /// </summary>
+    internal sealed class DelegatingMatcher : RequestMatcher
+    {
+        /// <summary>
+        /// The user-provided predicate to use to test for a match. This field is read-only.
+        /// </summary>
+        private readonly Predicate<HttpRequestMessage> _predicate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelegatingMatcher"/> class.
+        /// </summary>
+        /// <param name="predicate">The user-provided delegate to use for matching.</param>
+        internal DelegatingMatcher(Predicate<HttpRequestMessage> predicate)
+        {
+            _predicate = predicate;
+        }
+
+        /// <inheritdoc />
+        public override bool IsMatch(HttpRequestMessage request) => _predicate(request);
+    }
+}

--- a/src/HttpClientInterception/Matching/RegistrationMatcher.cs
+++ b/src/HttpClientInterception/Matching/RegistrationMatcher.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Just Eat, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace JustEat.HttpClientInterception.Matching
+{
+    /// <summary>
+    /// A class representing an implementation of <see cref="RequestMatcher"/> that matches against
+    /// an instance of <see cref="HttpInterceptionResponse"/>. This class cannot be inherited.
+    /// </summary>
+    internal sealed class RegistrationMatcher : RequestMatcher
+    {
+        /// <summary>
+        /// The string comparer to use to match URIs. This field is read-only.
+        /// </summary>
+        private readonly IEqualityComparer<string> _comparer;
+
+        /// <summary>
+        /// The <see cref="HttpInterceptionResponse"/> to use to generate URIs for comparison. This field is read-only.
+        /// </summary>
+        private readonly HttpInterceptionResponse _registration;
+
+        /// <summary>
+        /// The pre-computed URI that requests are required to match to. This field is read-only.
+        /// </summary>
+        private readonly string _expected;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegistrationMatcher"/> class.
+        /// </summary>
+        /// <param name="registration">The <see cref="HttpInterceptionResponse"/> to use for matching.</param>
+        /// <param name="comparer">The string comparer to use to compare URIs.</param>
+        internal RegistrationMatcher(HttpInterceptionResponse registration, IEqualityComparer<string> comparer)
+        {
+            _comparer = comparer;
+            _registration = registration;
+            _expected = GetUriStringForMatch(registration);
+        }
+
+        /// <inheritdoc />
+        public override bool IsMatch(HttpRequestMessage request)
+        {
+            if (request.RequestUri == null || request.Method != _registration.Method)
+            {
+                return false;
+            }
+
+            string actual = GetUriStringForMatch(_registration, request.RequestUri);
+
+            return _comparer.Equals(_expected, actual);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="string"/> that can be used to compare a URI against another.
+        /// </summary>
+        /// <param name="registration">The <see cref="HttpInterceptionResponse"/> to use to build the URI.</param>
+        /// <param name="uri">The optional <see cref="Uri"/> to use to build the URI if not using the one associated with <paramref name="registration"/>.</param>
+        /// <returns>
+        /// A <see cref="string"/> containing the URI to use for string comparisons for URIs.
+        /// </returns>
+        private static string GetUriStringForMatch(HttpInterceptionResponse registration, Uri uri = null)
+        {
+            var builder = new UriBuilder(uri ?? registration.RequestUri);
+
+            if (registration.IgnoreHost)
+            {
+                builder.Host = "*";
+            }
+
+            if (registration.IgnoreQuery)
+            {
+                builder.Query = string.Empty;
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/HttpClientInterception/Matching/RegistrationMatcher.cs
+++ b/src/HttpClientInterception/Matching/RegistrationMatcher.cs
@@ -70,6 +70,11 @@ namespace JustEat.HttpClientInterception.Matching
                 builder.Host = "*";
             }
 
+            if (registration.IgnorePath)
+            {
+                builder.Path = string.Empty;
+            }
+
             if (registration.IgnoreQuery)
             {
                 builder.Query = string.Empty;

--- a/src/HttpClientInterception/Matching/RequestMatcher.cs
+++ b/src/HttpClientInterception/Matching/RequestMatcher.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Just Eat, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Net.Http;
+
+namespace JustEat.HttpClientInterception.Matching
+{
+    /// <summary>
+    /// Represents a class that tests for matches for HTTP requests for a registered HTTP interception.
+    /// </summary>
+    internal abstract class RequestMatcher
+    {
+        /// <summary>
+        /// Returns a value indicating whether the specified <see cref="HttpRequestMessage"/> is considered a match.
+        /// </summary>
+        /// <param name="request">The HTTP request to consider a match against.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="request"/> is considered a match; otherwise <see langword="false"/>.
+        /// </returns>
+        public abstract bool IsMatch(HttpRequestMessage request);
+    }
+}

--- a/tests/HttpClientInterception.Benchmarks/JustEat.HttpClientInterception.Benchmarks.csproj
+++ b/tests/HttpClientInterception.Benchmarks/JustEat.HttpClientInterception.Benchmarks.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\..\src\HttpClientInterception\JustEat.HttpClientInterception.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.12" />
-    <PackageReference Include="Refit" Version="4.2.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.13" />
+    <PackageReference Include="Refit" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/tests/HttpClientInterception.Tests/Examples.cs
+++ b/tests/HttpClientInterception.Tests/Examples.cs
@@ -576,5 +576,25 @@ namespace JustEat.HttpClientInterception
                 }
             }
         }
+
+        [Fact]
+        public static async Task Use_Custom_Request_Matching()
+        {
+            // Arrange
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForRequest((request) => request.RequestUri.Host == "google.com")
+                .WithMediaType("text/html")
+                .WithContent(@"<!DOCTYPE html><html dir=""ltr"" lang=""en""><head><title>Google Search</title></head></html>");
+
+            var options = new HttpClientInterceptorOptions().Register(builder);
+
+            using (var client = options.CreateHttpClient())
+            {
+                // Act and Assert
+                (await client.GetStringAsync("https://google.com/")).ShouldContain("Google Search");
+                (await client.GetStringAsync("https://google.com/search")).ShouldContain("Google Search");
+                (await client.GetStringAsync("https://google.com/search?q=foo")).ShouldContain("Google Search");
+            }
+        }
     }
 }

--- a/tests/HttpClientInterception.Tests/Examples.cs
+++ b/tests/HttpClientInterception.Tests/Examples.cs
@@ -556,5 +556,25 @@ namespace JustEat.HttpClientInterception
             // Assert
             actual.ShouldBe(expected);
         }
+
+        [Fact]
+        public static async Task Use_Default_Response_For_Unmatched_Requests()
+        {
+            // Arrange
+            var options = new HttpClientInterceptorOptions()
+            {
+                OnMissingRegistration = (request) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound))
+            };
+
+            using (var client = options.CreateHttpClient())
+            {
+                // Act
+                using (var response = await client.GetAsync("https://google.com/"))
+                {
+                    // Assert
+                    response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+                }
+            }
+        }
     }
 }

--- a/tests/HttpClientInterception.Tests/Examples.cs
+++ b/tests/HttpClientInterception.Tests/Examples.cs
@@ -520,5 +520,41 @@ namespace JustEat.HttpClientInterception
             dotnetOrg.Login.ShouldBe("dotnet");
             dotnetOrg.Url.ShouldBe("https://api.github.com/orgs/dotnet");
         }
+
+        [Fact]
+        public static async Task Match_Any_Host_Name()
+        {
+            // Arrange
+            string expected = @"{""id"":12}";
+            string actual;
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForHttp()
+                .ForAnyHost()
+                .ForPath("orders")
+                .ForQuery("id=12")
+                .WithStatus(HttpStatusCode.OK)
+                .WithContent(expected);
+
+            var options = new HttpClientInterceptorOptions().Register(builder);
+
+            using (var client = options.CreateHttpClient())
+            {
+                // Act
+                actual = await client.GetStringAsync("http://myhost.net/orders?id=12");
+            }
+
+            // Assert
+            actual.ShouldBe(expected);
+
+            using (var client = options.CreateHttpClient())
+            {
+                // Act
+                actual = await client.GetStringAsync("http://myotherhost.net/orders?id=12");
+            }
+
+            // Assert
+            actual.ShouldBe(expected);
+        }
     }
 }

--- a/tests/HttpClientInterception.Tests/Examples.cs
+++ b/tests/HttpClientInterception.Tests/Examples.cs
@@ -26,11 +26,8 @@ namespace JustEat.HttpClientInterception
         {
             // Arrange
             var builder = new HttpRequestInterceptionBuilder()
-                .ForGet()
-                .ForHttps()
-                .ForHost("public.je-apis.com")
-                .ForPath("terms")
-                .WithJsonContent(new { Id = 1, Link = "https://www.just-eat.co.uk/privacy-policy" });
+                .Requests().ForGet().ForHttps().ForHost("public.je-apis.com").ForPath("terms")
+                .Responds().WithJsonContent(new { Id = 1, Link = "https://www.just-eat.co.uk/privacy-policy" });
 
             var options = new HttpClientInterceptorOptions()
                 .Register(builder);
@@ -582,9 +579,8 @@ namespace JustEat.HttpClientInterception
         {
             // Arrange
             var builder = new HttpRequestInterceptionBuilder()
-                .ForRequest((request) => request.RequestUri.Host == "google.com")
-                .WithMediaType("text/html")
-                .WithContent(@"<!DOCTYPE html><html dir=""ltr"" lang=""en""><head><title>Google Search</title></head></html>");
+                .Requests().For((request) => request.RequestUri.Host == "google.com")
+                .Responds().WithContent(@"<!DOCTYPE html><html dir=""ltr"" lang=""en""><head><title>Google Search</title></head></html>");
 
             var options = new HttpClientInterceptorOptions().Register(builder);
 

--- a/tests/HttpClientInterception.Tests/HttpAssert.cs
+++ b/tests/HttpClientInterception.Tests/HttpAssert.cs
@@ -83,6 +83,11 @@ namespace JustEat.HttpClientInterception
                             response.Content.Headers.ContentType.MediaType.ShouldBe(mediaType);
                         }
 
+                        if (response.Content == null)
+                        {
+                            return null;
+                        }
+
                         return await response.Content.ReadAsStringAsync();
                     }
                 }

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
@@ -63,6 +63,22 @@ namespace JustEat.HttpClientInterception
         }
 
         [Fact]
+        public static async Task GetResponseAsync_Returns_Null_If_Http_Method_Does_Not_Match()
+        {
+            // Arrange
+            var options = new HttpClientInterceptorOptions()
+                .Register(HttpMethod.Get, new Uri("https://google.com/"), contentFactory: EmptyContent);
+
+            var request = new HttpRequestMessage(HttpMethod.Post, "https://google.com/");
+
+            // Act
+            HttpResponseMessage actual = await options.GetResponseAsync(request);
+
+            // Assert
+            actual.ShouldBeNull();
+        }
+
+        [Fact]
         public static async Task GetResponseAsync_Returns_Null_If_Request_Uri_Does_Not_Match_Blank_Request()
         {
             // Arrange
@@ -379,6 +395,21 @@ namespace JustEat.HttpClientInterception
             await Assert.ThrowsAsync<HttpRequestException>(() => HttpAssert.GetAsync(options, "https://google.com/"));
             await HttpAssert.GetAsync(options, "https://google.co.uk/");
             await HttpAssert.GetAsync(options, "https://google.co.uk/");
+
+            // Arrange
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForHttps()
+                .ForGet()
+                .ForHost("bing.com");
+
+            options.ThrowOnMissingRegistration = true;
+            options.Register(builder);
+
+            await HttpAssert.GetAsync(options, "https://bing.com/");
+
+            options.Deregister(builder);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => HttpAssert.GetAsync(options, "https://bing.com/"));
         }
 
         [Fact]
@@ -486,6 +517,18 @@ namespace JustEat.HttpClientInterception
 
             // Act and Assert
             Assert.Throws<ArgumentNullException>("uri", () => options.Deregister(method, uri));
+        }
+
+        [Fact]
+        public static void Deregister_Throws_If_Builder_Is_Null()
+        {
+            // Arrange
+            var options = new HttpClientInterceptorOptions();
+
+            HttpRequestInterceptionBuilder builder = null;
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("builder", () => options.Deregister(builder));
         }
 
         [Fact]

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -976,6 +976,23 @@ namespace JustEat.HttpClientInterception
             actual2.ShouldBe(actual1);
         }
 
+        [Fact]
+        public static async Task Builder_Returns_Fallback_For_Missing_Registration()
+        {
+            // Arrange
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForHost("google.com")
+                .WithStatus(HttpStatusCode.BadRequest);
+
+            var options = new HttpClientInterceptorOptions().Register(builder);
+
+            options.OnMissingRegistration = (request) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway));
+
+            // Act and Assert
+            await HttpAssert.GetAsync(options, "http://google.com/", HttpStatusCode.BadRequest);
+            await HttpAssert.GetAsync(options, "http://bing.com/", HttpStatusCode.BadGateway);
+        }
+
         private sealed class CustomObject
         {
             internal enum Color

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -933,6 +933,49 @@ namespace JustEat.HttpClientInterception
             wasDelegateInvoked.ShouldBeFalse();
         }
 
+        [Fact]
+        public static async Task Builder_For_Any_Host_Registers_Interception()
+        {
+            // Arrange
+            string expected = "<html>foo></html>";
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForAnyHost()
+                .WithContent(expected);
+
+            var options = new HttpClientInterceptorOptions().Register(builder);
+
+            // Act
+            string actual1 = await HttpAssert.GetAsync(options, "http://google.com/");
+            string actual2 = await HttpAssert.GetAsync(options, "http://bing.com/");
+
+            // Assert
+            actual1.ShouldBe(expected);
+            actual2.ShouldBe(actual1);
+        }
+
+        [Fact]
+        public static async Task Builder_For_Any_Host_And_Query_Registers_Interception()
+        {
+            // Arrange
+            string expected = "<html>foo></html>";
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForAnyHost()
+                .IgnoringQuery()
+                .WithContent(expected);
+
+            var options = new HttpClientInterceptorOptions().Register(builder);
+
+            // Act
+            string actual1 = await HttpAssert.GetAsync(options, "http://google.com/?foo=bar");
+            string actual2 = await HttpAssert.GetAsync(options, "http://bing.com/?foo=baz");
+
+            // Assert
+            actual1.ShouldBe(expected);
+            actual2.ShouldBe(actual1);
+        }
+
         private sealed class CustomObject
         {
             internal enum Color

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -993,6 +993,16 @@ namespace JustEat.HttpClientInterception
             await HttpAssert.GetAsync(options, "http://bing.com/", HttpStatusCode.BadGateway);
         }
 
+        [Fact]
+        public static void RegisterWith_Validates_Parameters()
+        {
+            // Arrange
+            var builder = new HttpRequestInterceptionBuilder();
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("options", () => builder.RegisterWith(null));
+        }
+
         private sealed class CustomObject
         {
             internal enum Color

--- a/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
+++ b/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
@@ -13,9 +13,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
-    <PackageReference Include="Moq" Version="4.8.1" />
+    <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="Refit" Version="4.2.0" />
+    <PackageReference Include="Refit" Version="4.3.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
As discussed in #20, this PR adds support for:
  1. Matching requests to _any_ host name via a new `ForAnyHost()` method on `HttpRequestInterceptionBuilder`.
  1. Providing an optional fallback `HttpResponseMessage` for any unmatched registrations via a new `OnMissingRegistration` property on `HttpClientInterceptorOptions`.

/cc @stephenthrelfall
