### PR TITLE
Fix default port handling

### DIFF
--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -410,6 +410,11 @@ namespace JustEat.HttpClientInterception
                 keyPrefix += "IGNOREQUERY;";
             }
 
+            if (!interceptor.HasCustomPort)
+            {
+                builderForKey.Port = -1;
+            }
+
             return $"{keyPrefix};{interceptor.Method.Method}:{builderForKey}";
         }
 

--- a/src/HttpClientInterception/HttpInterceptionResponse.cs
+++ b/src/HttpClientInterception/HttpInterceptionResponse.cs
@@ -34,6 +34,8 @@ namespace JustEat.HttpClientInterception
 
         internal IEnumerable<KeyValuePair<string, IEnumerable<string>>> ContentHeaders { get; set; }
 
+        internal bool HasCustomPort { get; set; }
+
         internal bool IgnoreHost { get; set; }
 
         internal bool IgnorePath { get; set; }

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
@@ -43,6 +43,8 @@ namespace JustEat.HttpClientInterception
 
         private Version _version;
 
+        private bool _hasCustomPort;
+
         private bool _ignoreHost;
 
         private bool _ignorePath;
@@ -135,6 +137,7 @@ namespace JustEat.HttpClientInterception
         public HttpRequestInterceptionBuilder ForPort(int port)
         {
             _uriBuilder.Port = port;
+            _hasCustomPort = port != -1;
             return this;
         }
 
@@ -629,6 +632,7 @@ namespace JustEat.HttpClientInterception
                 ContentFactory = _contentFactory ?? EmptyContentFactory,
                 ContentStream = _contentStream,
                 ContentMediaType = _mediaType,
+                HasCustomPort = _hasCustomPort,
                 IgnoreHost = _ignoreHost,
                 IgnorePath = _ignorePath,
                 IgnoreQuery = _ignoreQuery,

--- a/src/HttpClientInterception/Matching/RegistrationMatcher.cs
+++ b/src/HttpClientInterception/Matching/RegistrationMatcher.cs
@@ -65,6 +65,11 @@ namespace JustEat.HttpClientInterception.Matching
         {
             var builder = new UriBuilder(uri ?? registration.RequestUri);
 
+            if (!registration.HasCustomPort)
+            {
+                builder.Port = -1;
+            }
+
             if (registration.IgnoreHost)
             {
                 builder.Host = "*";

--- a/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs
+++ b/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs
@@ -39,7 +39,6 @@ namespace JustEat.HttpClientInterception
             builder
                 .Requests()
                 .ForHttps()
-                .ForPort(443)
                 .ForHost("files.domain.com")
                 .ForPath("setup.exe")
                 .ForQuery(string.Empty)

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -1040,6 +1040,33 @@ namespace JustEat.HttpClientInterception
             Assert.Throws<ArgumentNullException>("options", () => builder.RegisterWith(null));
         }
 
+        [Fact]
+        public static async Task Using_The_Same_Builder_For_Multiple_Registrations_On_The_Same_Host_Retains_Default_Port()
+        {
+            // Arrange
+            var options = new HttpClientInterceptorOptions()
+            {
+                ThrowOnMissingRegistration = true
+            };
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForHttps()
+                .ForHost("api.github.com")
+                .ForPath("orgs/justeat")
+                .RegisterWith(options);
+
+            // Change to a different scheme without an explicit port
+            builder = builder
+                .ForHttp()
+                .RegisterWith(options);
+
+            // Act and Assert
+            await HttpAssert.GetAsync(options, "http://api.github.com/orgs/justeat");
+            await HttpAssert.GetAsync(options, "http://api.github.com:80/orgs/justeat");
+            await HttpAssert.GetAsync(options, "https://api.github.com/orgs/justeat");
+            await HttpAssert.GetAsync(options, "https://api.github.com:443/orgs/justeat");
+        }
+
         private sealed class CustomObject
         {
             internal enum Color


### PR DESCRIPTION
While updating the benchmarks as part of #24, I found that when the scheme (HTTP, HTTPS etc.) of a builder is changed when using it for multiple registrations, the port associated with the first scheme was associated with subsequent registrations for another scheme.

This was because `UriBuilder` copies the port through when creating a `UriBuilder` from another, which caused the `ToString()` calls used to do the request matching to contain the wrong port, and thus not match.

This wasn't a problem before `1.2.0` as the `UriBuilder.Uri` was used instead, which automatically omitted the port in the string if it was the default port for the scheme. The changes in `1.2.0` broke this implicit behaviour because `ToString()` was used on `UriBuilder` internally so that invalid values (such as `*`) could be used for wildcards on parts of the URI, such as the hostname, which would have caused the `Uri` property to throw.

Now whether the port has been changed on a builder is tracked internally so that the behaviour for default ports for HTTP and HTTPS is intuitive if `ForPort()` is never called. If it is called, the value is retained and the caller is expected to keep it updated for themselves; calling it with a value of `-1` resets the behaviour to the default handling.