### PR TITLE
Analyzer dependencies need to be private

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,13 +2,13 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
     <Compile Include="$(MSBuildThisFileDirectory)CommonAssemblyInfo.cs" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.0" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.0" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.6.519" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="3.1.2" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="Text.Analyzers" Version="2.6.0" />
+    <PackageReference Include="Text.Analyzers" Version="2.6.0" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <Authors>Just Eat</Authors>


### PR DESCRIPTION
Make analyzer dependencies added by #29 private so they don't propagate into the published NuGet package.
