### PR TITLE
Add convenience method for form content

### DIFF
--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -22,6 +22,11 @@ namespace JustEat.HttpClientInterception
     public class HttpClientInterceptorOptions
     {
         /// <summary>
+        /// The media type to use for a URL-encoded form.
+        /// </summary>
+        internal const string FormMediaType = "application/x-www-form-urlencoded";
+
+        /// <summary>
         /// The media type to use for JSON.
         /// </summary>
         internal const string JsonMediaType = "application/json";

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilderExtensions.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilderExtensions.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace JustEat.HttpClientInterception
@@ -152,6 +154,44 @@ namespace JustEat.HttpClientInterception
             }
 
             return builder.WithContent(() => Encoding.UTF8.GetBytes(content ?? string.Empty));
+        }
+
+        /// <summary>
+        /// Sets the parameters to use as the form URL-encoded response content.
+        /// </summary>
+        /// <param name="builder">The <see cref="HttpRequestInterceptionBuilder"/> to use.</param>
+        /// <param name="parameters">The parameters to use for the form URL-encoded content.</param>
+        /// <returns>
+        /// The value specified by <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> or <paramref name="parameters"/> is <see langword="null"/>.
+        /// </exception>
+        public static HttpRequestInterceptionBuilder WithFormContent(
+            this HttpRequestInterceptionBuilder builder,
+            IEnumerable<KeyValuePair<string, string>> parameters)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            Func<Task<byte[]>> contentFactory = async () =>
+            {
+                using (var content = new FormUrlEncodedContent(parameters))
+                {
+                    return await content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                }
+            };
+
+            return builder
+                .WithMediaType(HttpClientInterceptorOptions.FormMediaType)
+                .WithContent(contentFactory);
         }
 
         /// <summary>

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -776,6 +776,43 @@ namespace JustEat.HttpClientInterception
         }
 
         [Fact]
+        public static void WithFormContent_Validates_Parameters()
+        {
+            // Arrange
+            var builder = new HttpRequestInterceptionBuilder();
+            IEnumerable<KeyValuePair<string, string>> parameters = null;
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("builder", () => (null as HttpRequestInterceptionBuilder).WithFormContent(parameters));
+            Assert.Throws<ArgumentNullException>("parameters", () => builder.WithFormContent(parameters));
+        }
+
+        [Fact]
+        public static async Task WithFormContent_Returns_Correct_Response()
+        {
+            // Arrange
+            var requestUri = "https://api.twitter.com/oauth/request_token";
+            var parameters = new Dictionary<string, string>()
+            {
+                { "oauth_callback_confirmed", "true" },
+                { "oauth_token", "a b c" },
+                { "oauth_token_secret", "U5LJUL3eS+fl9bj9xqHKXyHpBc8=" },
+            };
+
+            var options = new HttpClientInterceptorOptions();
+            var builder = new HttpRequestInterceptionBuilder()
+                .Requests().ForPost().ForUrl(requestUri)
+                .Responds().WithFormContent(parameters)
+                .RegisterWith(options);
+
+            // Act
+            string actual = await HttpAssert.PostAsync(options, requestUri, new { }, mediaType: "application/x-www-form-urlencoded");
+
+            // Assert
+            actual.ShouldBe("oauth_callback_confirmed=true&oauth_token=a+b+c&oauth_token_secret=U5LJUL3eS%2Bfl9bj9xqHKXyHpBc8%3D");
+        }
+
+        [Fact]
         public static void WithJsonContent_Validates_Parameters()
         {
             // Arrange


### PR DESCRIPTION
Add a convenience method for responding with URL-encoded form content, such as a response from an OAuth token endpoint.