### PR TITLE
Add netstandard2.0 TFM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A .NET Standard library for intercepting server-side HTTP dependencies.
 
 ## Introduction
 
-This library provides functionality for intercepting HTTP requests made using the `HttpClient` class in code targeting .NET Standard  1.3 and later and .NET Framework 4.6.1 and later.
+This library provides functionality for intercepting HTTP requests made using the `HttpClient` class in code targeting .NET Standard 1.3 and 2.0 (and later), and .NET Framework 4.6.1 and later.
 
 The primary use-case is for providing stub responses for use in tests for applications, such as an ASP.NET Core application, to drive your functional test scenarios.
 

--- a/build.sh
+++ b/build.sh
@@ -41,6 +41,7 @@ if [ "$dotnet_version" != "$CLI_VERSION" ]; then
 fi
 
 dotnet build ./src/HttpClientInterception/JustEat.HttpClientInterception.csproj --output $artifacts --configuration $configuration --framework "netstandard1.3" || exit 1
+dotnet build ./src/HttpClientInterception/JustEat.HttpClientInterception.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
 
 if [ $skipTests == 0 ]; then
     dotnet test ./tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj --output $artifacts --configuration $configuration || exit 1

--- a/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
+++ b/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>HttpClient Interception</AssemblyTitle>
     <DebugType>full</DebugType>
@@ -8,7 +8,7 @@
     <PackageId>JustEat.HttpClientInterception</PackageId>
     <RootNamespace>JustEat.HttpClientInterception</RootNamespace>
     <Summary>A .NET library for intercepting server-side HTTP dependencies.</Summary>
-    <TargetFrameworks>netstandard1.3;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
Add a Target Framework Moniker for .NET Standard 2.0 to simplify the dependency graph for .NET Core 2.0 and later.