### PR TITLE
Update test dependencies

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -17,7 +17,7 @@ $testProjects = @(
     (Join-Path $solutionPath "samples\SampleApp.Tests\SampleApp.Tests.csproj")
 )
 
-$dotnetVersion = (Get-Content $sdkFile | ConvertFrom-Json).sdk.version
+$dotnetVersion = (Get-Content $sdkFile | Out-String | ConvertFrom-Json).sdk.version
 
 if ($OutputPath -eq "") {
     $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"
@@ -37,9 +37,15 @@ if (((Get-Command "dotnet.exe" -ErrorAction SilentlyContinue) -eq $null) -and ((
     $installDotNetSdk = $true
 }
 else {
-    $installedDotNetVersion = (dotnet --version | Out-String).Trim()
+    Try {
+        $installedDotNetVersion = (dotnet --version 2>&1 | Out-String).Trim()
+    }
+    Catch {
+        $installedDotNetVersion = "?"
+    }
+
     if ($installedDotNetVersion -ne $dotnetVersion) {
-        Write-Host "The required version of the .NET Core SDK is not installed. Expected $dotnetVersion but $installedDotNetVersion was found."
+        Write-Host "The required version of the .NET Core SDK is not installed. Expected $dotnetVersion."
         $installDotNetSdk = $true
     }
 }

--- a/samples/SampleApp.Tests/SampleApp.Tests.csproj
+++ b/samples/SampleApp.Tests/SampleApp.Tests.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\HttpClientInterception\JustEat.HttpClientInterception.csproj" />

--- a/tests/HttpClientInterception.Benchmarks/JustEat.HttpClientInterception.Benchmarks.csproj
+++ b/tests/HttpClientInterception.Benchmarks/JustEat.HttpClientInterception.Benchmarks.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\..\src\HttpClientInterception\JustEat.HttpClientInterception.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.0" />
     <PackageReference Include="Refit" Version="4.6.16" />
   </ItemGroup>
 </Project>

--- a/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
+++ b/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Refit" Version="4.6.16" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />


### PR DESCRIPTION
  1. Update BenchmarkDotNet and xunit to their latest NuGet package versions.
  1. Port some `Build.ps1` fixes from GitHub Enterprise for Windows Server occasional weirdness