### PR TITLE
Fix build for Mac/Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .dotnetcli
+.idea
 .metadata
 .settings
 .vs

--- a/build.sh
+++ b/build.sh
@@ -40,8 +40,7 @@ if [ "$dotnet_version" != "$CLI_VERSION" ]; then
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 fi
 
-dotnet build ./src/HttpClientInterception/JustEat.HttpClientInterception.csproj --output $artifacts --configuration $configuration --framework "netstandard1.3" || exit 1
-dotnet build ./src/HttpClientInterception/JustEat.HttpClientInterception.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
+dotnet build ./src/HttpClientInterception/JustEat.HttpClientInterception.csproj --output $artifacts --configuration $configuration || exit 1
 
 if [ $skipTests == 0 ]; then
     dotnet test ./tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj --output $artifacts --configuration $configuration || exit 1

--- a/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
+++ b/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>HttpClient Interception</AssemblyTitle>
     <DebugType>full</DebugType>
@@ -8,7 +8,8 @@
     <PackageId>JustEat.HttpClientInterception</PackageId>
     <RootNamespace>JustEat.HttpClientInterception</RootNamespace>
     <Summary>A .NET library for intercepting server-side HTTP dependencies.</Summary>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
Replaces #47.

  1. Fix the build for macOS/Linux when `build.sh` wasn't used.
  1. Ignore settings folder for Rider.
