### PR TITLE
Update benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,24 +177,23 @@ Further examples of using the library can be found by following the links below:
 
 ### Benchmarks
 
-Generated with the [Benchmarks project](https://github.com/justeat/httpclient-interception/blob/master/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs "JustEat.HttpClientInterception benchmark code") using [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet "BenchmarkDotNet on GitHub.com") using commit [c09c38b](https://github.com/justeat/httpclient-interception/commit/c09c38bad3ed5db6cfffdbaebeac33c2d286764f "Benchmark commit") on 11/03/2018.
+Generated with the [Benchmarks project](https://github.com/justeat/httpclient-interception/blob/master/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs "JustEat.HttpClientInterception benchmark code") using [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet "BenchmarkDotNet on GitHub.com") using commit [e189875](https://github.com/justeat/httpclient-interception/commit/e18987518f279ece7ad4631d21c5e986733fdab3 "Benchmark commit") on 14/10/2018.
 
 ``` ini
-BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
-Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical cores and 4 physical cores
-Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
-.NET Core SDK=2.1.4
-  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
-  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
+BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17763
+Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=2.1.403
+  [Host]     : .NET Core 2.1.5 (CoreCLR 4.6.26919.02, CoreFX 4.6.26919.02), 64bit RyuJIT
+  DefaultJob : .NET Core 2.1.5 (CoreCLR 4.6.26919.02, CoreFX 4.6.26919.02), 64bit RyuJIT
 ```
 
- |    Method |      Mean |     Error |    StdDev |
- |---------- |----------:|----------:|----------:|
- | [`GetBytes`](https://github.com/justeat/httpclient-interception/blob/c09c38bad3ed5db6cfffdbaebeac33c2d286764f/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L73-L77 "Benchmark using a byte array") |  8.310 μs | 0.0916 μs | 0.0857 μs |
- | [`GetHtml`](https://github.com/justeat/httpclient-interception/blob/c09c38bad3ed5db6cfffdbaebeac33c2d286764f/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L79-L83 "Benchmark using HTML") |  8.476 μs | 0.0462 μs | 0.0361 μs |
- | [`GetJson`](https://github.com/justeat/httpclient-interception/blob/c09c38bad3ed5db6cfffdbaebeac33c2d286764f/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L85-L90 "Benchmark using JSON") | 17.519 μs | 0.2440 μs | 0.2282 μs |
- | [`GetStream`](https://github.com/justeat/httpclient-interception/blob/c09c38bad3ed5db6cfffdbaebeac33c2d286764f/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L92-L98 "Benchmark using a stream") | 72.442 μs | 0.9177 μs | 0.8135 μs |
- | [`Refit`](https://github.com/justeat/httpclient-interception/blob/c09c38bad3ed5db6cfffdbaebeac33c2d286764f/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L100-L104 "Benchmark using Refit") | 46.388 μs | 0.4742 μs | 0.4436 μs |
+|    Method |      Mean |     Error |    StdDev |    Median |  Gen 0 | Allocated |
+|---------- |----------:|----------:|----------:|----------:|-------:|----------:|
+| [`GetBytes`](https://github.com/justeat/httpclient-interception/blob/c09c38bad3ed5db6cfffdbaebeac33c2d286764f/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L73-L77 "Benchmark using a byte array") |  8.675 μs | 0.2513 μs | 0.7330 μs |  8.478 μs | 1.3275 |   4.13 KB |
+| [`GetHtml`](https://github.com/justeat/httpclient-interception/blob/c09c38bad3ed5db6cfffdbaebeac33c2d286764f/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L79-L83 "Benchmark using HTML") |  9.406 μs | 0.2480 μs | 0.7313 μs |  9.141 μs | 1.4191 |   4.41 KB |
+| [`GetJson`](https://github.com/justeat/httpclient-interception/blob/c09c38bad3ed5db6cfffdbaebeac33c2d286764f/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L85-L90 "Benchmark using JSON") | 17.653 μs | 0.3501 μs | 0.5849 μs | 17.428 μs | 3.0518 |   9.44 KB |
+| [`GetStream`](https://github.com/justeat/httpclient-interception/blob/c09c38bad3ed5db6cfffdbaebeac33c2d286764f/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L92-L98 "Benchmark using a stream") | 74.822 μs | 1.4916 μs | 3.7695 μs | 73.784 μs | 1.0986 |   3.43 KB |
+| [`Refit`](https://github.com/justeat/httpclient-interception/blob/c09c38bad3ed5db6cfffdbaebeac33c2d286764f/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L100-L104 "Benchmark using Refit") | 43.953 μs | 0.8722 μs | 0.9694 μs | 44.026 μs | 4.8218 |  14.97 KB |
 
 ## Feedback
 

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ if [ "$dotnet_version" != "$CLI_VERSION" ]; then
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 fi
 
-dotnet build ./src/HttpClientInterception/JustEat.HttpClientInterception.csproj --output $artifacts --configuration $configuration || exit 1
+dotnet build ./HttpClientInterception.sln --output $artifacts --configuration $configuration || exit 1
 
 if [ $skipTests == 0 ]; then
     dotnet test ./tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj --output $artifacts --configuration $configuration || exit 1

--- a/samples/SampleApp.Tests/SampleApp.Tests.csproj
+++ b/samples/SampleApp.Tests/SampleApp.Tests.csproj
@@ -7,6 +7,7 @@
     <Content Include="testsettings.json;xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />

--- a/samples/SampleApp.Tests/testsettings.json
+++ b/samples/SampleApp.Tests/testsettings.json
@@ -1,4 +1,12 @@
-﻿{
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "System": "Warning",
+      "System.Net.Http.HttpClient": "Information",
+      "Microsoft": "Warning"
+    }
+  },
   "Organization": "weyland-yutani",
   "UserAgent": "JustEat-SampleApp-Tests"
 }


### PR DESCRIPTION
  1. Update the benchmark results in `README` for 1.2.2 and .NET Core 2.1.
  1. Build the solution in `build.sh` to work around occasional MSBuild file locks.
  1. Use [xunit-logging](https://github.com/martincostello/xunit-logging) to root the logs from the sample application's tests to xunit's output.
