### PR TITLE
Match by request headers

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -105,8 +105,8 @@ function DotNetTest {
         $openCoverVersion = "4.6.519"
         $openCoverPath = Join-Path $nugetPath "OpenCover\$openCoverVersion\tools\OpenCover.Console.exe"
 
-        $reportGeneratorVersion = "3.1.2"
-        $reportGeneratorPath = Join-Path $nugetPath "ReportGenerator\$reportGeneratorVersion\tools\ReportGenerator.exe"
+        $reportGeneratorVersion = "4.0.2"
+        $reportGeneratorPath = Join-Path $nugetPath "ReportGenerator\$reportGeneratorVersion\tools\netcoreapp2.0\ReportGenerator.dll"
 
         $coverageOutput = Join-Path $OutputPath "code-coverage.xml"
         $reportOutput = Join-Path $OutputPath "coverage"
@@ -123,7 +123,7 @@ function DotNetTest {
             -skipautoprops `
             `"-filter:+[JustEat.HttpClientInterception]* -[JustEat.HttpClientInterception.Tests]*`"
 
-        & $reportGeneratorPath `
+        & $dotnet $reportGeneratorPath `
             `"-reports:$coverageOutput`" `
             `"-targetdir:$reportOutput`" `
             -verbosity:Warning

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.6.519" PrivateAssets="All" />
-    <PackageReference Include="ReportGenerator" Version="3.1.2" PrivateAssets="All" />
+    <PackageReference Include="ReportGenerator" Version="4.0.2" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="Text.Analyzers" Version="2.6.2" PrivateAssets="All" />
   </ItemGroup>

--- a/samples/SampleApp.Tests/HttpServerFixture.cs
+++ b/samples/SampleApp.Tests/HttpServerFixture.cs
@@ -7,6 +7,7 @@ using JustEat.HttpClientInterception;
 using MartinCostello.Logging.XUnit;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
@@ -52,6 +53,12 @@ namespace SampleApp.Tests
 
             // Route logs to xunit test output
             builder.ConfigureLogging((p) => p.AddXUnit());
+        }
+
+        protected override IWebHostBuilder CreateWebHostBuilder()
+        {
+            return base.CreateWebHostBuilder()
+                .UseSolutionRelativeContentRoot("samples/SampleApp");
         }
 
         /// <summary>

--- a/samples/SampleApp.Tests/SampleApp.Tests.csproj
+++ b/samples/SampleApp.Tests/SampleApp.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Shouldly" Version="3.0.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\HttpClientInterception\JustEat.HttpClientInterception.csproj" />

--- a/src/HttpClientInterception/HttpInterceptionResponse.cs
+++ b/src/HttpClientInterception/HttpInterceptionResponse.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Just Eat, 2017. All rights reserved.
+﻿// Copyright (c) Just Eat, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
@@ -21,6 +21,8 @@ namespace JustEat.HttpClientInterception
         internal int? Priority { get; set; }
 
         internal string ReasonPhrase { get; set; }
+
+        internal IEnumerable<KeyValuePair<string, IEnumerable<string>>> RequestHeaders { get; set; }
 
         internal Uri RequestUri { get; set; }
 

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilderExtensions.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilderExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Just Eat, 2017. All rights reserved.
+﻿// Copyright (c) Just Eat, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
@@ -181,17 +181,17 @@ namespace JustEat.HttpClientInterception
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            Func<Task<byte[]>> contentFactory = async () =>
+            async Task<byte[]> ContentFactoryAsync()
             {
                 using (var content = new FormUrlEncodedContent(parameters))
                 {
                     return await content.ReadAsByteArrayAsync().ConfigureAwait(false);
                 }
-            };
+            }
 
             return builder
                 .WithMediaType(HttpClientInterceptorOptions.FormMediaType)
-                .WithContent(contentFactory);
+                .WithContent(ContentFactoryAsync);
         }
 
         /// <summary>
@@ -221,15 +221,15 @@ namespace JustEat.HttpClientInterception
                 throw new ArgumentNullException(nameof(content));
             }
 
-            Func<byte[]> contentFactory = () =>
+            byte[] ContentFactory()
             {
                 string json = JsonConvert.SerializeObject(content, settings ?? new JsonSerializerSettings());
                 return Encoding.UTF8.GetBytes(json);
-            };
+            }
 
             return builder
                 .WithMediaType(HttpClientInterceptorOptions.JsonMediaType)
-                .WithContent(contentFactory);
+                .WithContent(ContentFactory);
         }
 
         /// <summary>

--- a/tests/HttpClientInterception.Benchmarks/JustEat.HttpClientInterception.Benchmarks.csproj
+++ b/tests/HttpClientInterception.Benchmarks/JustEat.HttpClientInterception.Benchmarks.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\..\src\HttpClientInterception\JustEat.HttpClientInterception.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.2" />
     <PackageReference Include="Refit" Version="4.6.48" />
   </ItemGroup>
 </Project>

--- a/tests/HttpClientInterception.Tests/Examples.cs
+++ b/tests/HttpClientInterception.Tests/Examples.cs
@@ -1,10 +1,9 @@
-// Copyright (c) Just Eat, 2017. All rights reserved.
+﻿// Copyright (c) Just Eat, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -145,8 +144,8 @@ namespace JustEat.HttpClientInterception
                 .ForHttps()
                 .ForHost("public.je-apis.com")
                 .ForPath("terms")
-                .WithJsonContent(new { Id = 1, Link = "https://www.just-eat.co.uk/privacy-policy" })
-                .WithInterceptionCallback((request) => request.Headers.GetValues("Accept-Tenant").FirstOrDefault() == "uk");
+                .ForRequestHeader("Accept-Tenant", "uk")
+                .WithJsonContent(new { Id = 1, Link = "https://www.just-eat.co.uk/privacy-policy" });
 
             var options = new HttpClientInterceptorOptions()
                 .Register(builder);

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -656,7 +656,7 @@ namespace JustEat.HttpClientInterception
 
             bool wasDelegateInvoked = false;
 
-            Action<HttpRequestMessage> onIntercepted = (request) =>
+            void OnIntercepted(HttpRequestMessage request)
             {
                 request.ShouldNotBeNull();
                 request.Method.ShouldBe(HttpMethod.Post);
@@ -669,12 +669,12 @@ namespace JustEat.HttpClientInterception
                 body.Value<string>("foo").ShouldBe("bar");
 
                 wasDelegateInvoked = true;
-            };
+            }
 
             var builder = new HttpRequestInterceptionBuilder()
                 .ForPost()
                 .ForUri(requestUri)
-                .WithInterceptionCallback(onIntercepted);
+                .WithInterceptionCallback(OnIntercepted);
 
             var options = new HttpClientInterceptorOptions().Register(builder);
 
@@ -694,7 +694,7 @@ namespace JustEat.HttpClientInterception
 
             bool wasDelegateInvoked = false;
 
-            Func<HttpRequestMessage, Task> onIntercepted = async (request) =>
+            async Task OnInterceptedAsync(HttpRequestMessage request)
             {
                 request.ShouldNotBeNull();
                 request.Method.ShouldBe(HttpMethod.Post);
@@ -707,12 +707,12 @@ namespace JustEat.HttpClientInterception
                 body.Value<string>("foo").ShouldBe("bar");
 
                 wasDelegateInvoked = true;
-            };
+            }
 
             var builder = new HttpRequestInterceptionBuilder()
                 .ForPost()
                 .ForUri(requestUri)
-                .WithInterceptionCallback(onIntercepted);
+                .WithInterceptionCallback(OnInterceptedAsync);
 
             var options = new HttpClientInterceptorOptions().Register(builder);
 
@@ -907,16 +907,16 @@ namespace JustEat.HttpClientInterception
 
             bool wasDelegateInvoked = false;
 
-            Func<HttpRequestMessage, Task<bool>> onIntercepted = (request) =>
+            Task<bool> OnInterceptedAsync(HttpRequestMessage request)
             {
                 wasDelegateInvoked = true;
                 return Task.FromResult(true);
-            };
+            }
 
             var builder = new HttpRequestInterceptionBuilder()
                 .ForPost()
                 .ForUri(requestUri)
-                .WithInterceptionCallback(onIntercepted);
+                .WithInterceptionCallback(OnInterceptedAsync);
 
             var options = new HttpClientInterceptorOptions().Register(builder);
 
@@ -936,16 +936,16 @@ namespace JustEat.HttpClientInterception
 
             bool wasDelegateInvoked = false;
 
-            Func<HttpRequestMessage, Task<bool>> onIntercepted = (request) =>
+            Task<bool> OnInterceptedAsync(HttpRequestMessage request)
             {
                 wasDelegateInvoked = true;
                 return Task.FromResult(false);
-            };
+            }
 
             var builder = new HttpRequestInterceptionBuilder()
                 .ForPost()
                 .ForUri(requestUri)
-                .WithInterceptionCallback(onIntercepted);
+                .WithInterceptionCallback(OnInterceptedAsync);
 
             var options = new HttpClientInterceptorOptions().Register(builder);
             options.ThrowOnMissingRegistration = true;

--- a/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
+++ b/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Refit" Version="4.6.48" />
     <PackageReference Include="Shouldly" Version="3.0.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />


### PR DESCRIPTION
This PR adds support for simple matching of requests using HTTP request headers if the URI matches an registered interception.

For example, the following request will only be intercepted if an HTTP `GET` request to `https://public.je-apis.com/terms` specifies an `Accept` header with a value of `application/json`:

```csharp
var options = new HttpClientInterceptorOptions();

var builder = new HttpRequestInterceptionBuilder()
    .Requests()
        .ForUrl("https://public.je-apis.com/terms")
        .ForRequestHeader("accept", "application/json")
    .Responds()
        .WithJsonContent(new { Id = 1, Link = "https://www.just-eat.co.uk/privacy-policy" })
    .RegisterWith(options);
```

Also supported are headers with multiple values, and multiple headers. Only exact matching of _all_ headers specified will match for a request interception.

The `WithInterceptionCallback()` method should continue to be used for more advanced scenarios.

This PR also:
  1. Updates NuGet dependencies to their latest versions.
  1. Uses local methods instead of lambda delegates in some places.
  1. Fixes the test for the sample project when run from Visual Studio.