### PR TITLE
Get package versions from file

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -107,11 +107,12 @@ function DotNetTest {
         }
 
         $nugetPath = Join-Path $env:USERPROFILE ".nuget\packages"
+        $propsFile = Join-Path $solutionPath "Directory.Build.props"
 
-        $openCoverVersion = "4.7.922"
+        $openCoverVersion = (Select-Xml -Path $propsFile -XPath "//PackageReference[@Include='OpenCover']/@Version").Node.'#text'
         $openCoverPath = Join-Path $nugetPath "OpenCover\$openCoverVersion\tools\OpenCover.Console.exe"
 
-        $reportGeneratorVersion = "4.1.9"
+        $reportGeneratorVersion = (Select-Xml -Path $propsFile -XPath "//PackageReference[@Include='ReportGenerator']/@Version").Node.'#text'
         $reportGeneratorPath = Join-Path $nugetPath "ReportGenerator\$reportGeneratorVersion\tools\netcoreapp2.0\ReportGenerator.dll"
 
         $coverageOutput = Join-Path $OutputPath "code-coverage.xml"


### PR DESCRIPTION
Get the versions of OpenCover and ReportGenerator by parsing the `Directory.Build.props` file, rather than hard-coding.
