### PR TITLE
Add support for matching by request content

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dotnet add package JustEat.HttpClientInterception
 
 ##### Fluent API
 
-Below is a minimal example of intercepting a request to an HTTP API for a JSON resource to return a custom response using the fluent API:
+Below is a minimal example of intercepting an HTTP GET request to an API for a JSON resource to return a custom response using the fluent API:
 
 ```csharp
 // using JustEat.HttpClientInterception;

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -394,7 +394,7 @@ namespace JustEat.HttpClientInterception
         /// </returns>
         private static string BuildKey(HttpInterceptionResponse interceptor)
         {
-            if (interceptor.UserMatcher != null)
+            if (interceptor.UserMatcher != null || interceptor.ContentMatcher != null)
             {
                 // Use the internal matcher's hash code as UserMatcher (a delegate)
                 // will always return the hash code. See https://stackoverflow.com/q/6624151/1064169

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -344,10 +344,14 @@ namespace JustEat.HttpClientInterception
                 throw new ArgumentNullException(nameof(request));
             }
 
-            if (!TryGetResponse(request, out HttpInterceptionResponse response))
+            var matchResult = await TryGetResponseAsync(request).ConfigureAwait(false);
+
+            if (!matchResult.Item1)
             {
                 return null;
             }
+
+            var response = matchResult.Item2;
 
             if (response.OnIntercepted != null && !await response.OnIntercepted(request).ConfigureAwait(false))
             {
@@ -484,15 +488,21 @@ namespace JustEat.HttpClientInterception
             return result;
         }
 
-        private bool TryGetResponse(HttpRequestMessage request, out HttpInterceptionResponse response)
+        private async Task<Tuple<bool, HttpInterceptionResponse>> TryGetResponseAsync(HttpRequestMessage request)
         {
-            response = _mappings.Values
+            var responses = _mappings.Values
                 .OrderByDescending((p) => p.Priority.HasValue)
-                .ThenBy((p) => p.Priority)
-                .Where((p) => p.InternalMatcher.IsMatch(request))
-                .FirstOrDefault();
+                .ThenBy((p) => p.Priority);
 
-            return response != null;
+            foreach (var response in responses)
+            {
+                if (await response.InternalMatcher.IsMatchAsync(request).ConfigureAwait(false))
+                {
+                    return Tuple.Create(true, response);
+                }
+            }
+
+            return Tuple.Create<bool, HttpInterceptionResponse>(false, null);
         }
 
         private void ConfigureMatcherAndRegister(HttpInterceptionResponse registration)

--- a/src/HttpClientInterception/HttpClientInterceptorOptionsExtensions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptionsExtensions.cs
@@ -206,13 +206,13 @@ namespace JustEat.HttpClientInterception
                 throw new ArgumentNullException(nameof(content));
             }
 
-            Func<byte[]> contentFactory = () =>
+            byte[] ContentFactory()
             {
                 string json = JsonConvert.SerializeObject(content);
                 return Encoding.UTF8.GetBytes(json);
-            };
+            }
 
-            return options.Register(HttpMethod.Get, new Uri(uriString), contentFactory, statusCode);
+            return options.Register(HttpMethod.Get, new Uri(uriString), ContentFactory, statusCode);
         }
 
         /// <summary>

--- a/src/HttpClientInterception/HttpInterceptionResponse.cs
+++ b/src/HttpClientInterception/HttpInterceptionResponse.cs
@@ -12,6 +12,8 @@ namespace JustEat.HttpClientInterception
 {
     internal sealed class HttpInterceptionResponse
     {
+        internal Func<HttpContent, Task<bool>> ContentMatcher { get; set; }
+
         internal Predicate<HttpRequestMessage> UserMatcher { get; set; }
 
         internal Matching.RequestMatcher InternalMatcher { get; set; }

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
@@ -21,6 +21,8 @@ namespace JustEat.HttpClientInterception
 
         private Func<Task<byte[]>> _contentFactory;
 
+        private Func<HttpContent, Task<bool>> _contentMatcher;
+
         private Func<Task<Stream>> _contentStream;
 
         private IDictionary<string, ICollection<string>> _contentHeaders;
@@ -816,11 +818,31 @@ namespace JustEat.HttpClientInterception
             return this;
         }
 
+        /// <summary>
+        /// Configures the builder to match any request whose HTTP content meets the criteria defined by the specified predicate.
+        /// </summary>
+        /// <param name="predicate">
+        /// A delegate to a method which returns <see langword="true"/> if the
+        /// request's HTTP content is considered a match; otherwise <see langword="false"/>.
+        /// </param>
+        /// <returns>
+        /// The current <see cref="HttpRequestInterceptionBuilder"/>.
+        /// </returns>
+        /// <remarks>
+        /// Pass a value of <see langword="null"/> to remove a previously-registered custom content matching predicate.
+        /// </remarks>
+        public HttpRequestInterceptionBuilder ForContent(Func<HttpContent, Task<bool>> predicate)
+        {
+            _contentMatcher = predicate;
+            return this;
+        }
+
         internal HttpInterceptionResponse Build()
         {
             var response = new HttpInterceptionResponse()
             {
                 ContentFactory = _contentFactory ?? EmptyContentFactory,
+                ContentMatcher = _contentMatcher,
                 ContentStream = _contentStream,
                 ContentMediaType = _mediaType,
                 HasCustomPort = _hasCustomPort,

--- a/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
+++ b/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/src/HttpClientInterception/Matching/DelegatingMatcher.cs
+++ b/src/HttpClientInterception/Matching/DelegatingMatcher.cs
@@ -1,8 +1,9 @@
-// Copyright (c) Just Eat, 2017. All rights reserved.
+﻿// Copyright (c) Just Eat, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace JustEat.HttpClientInterception.Matching
 {
@@ -27,6 +28,7 @@ namespace JustEat.HttpClientInterception.Matching
         }
 
         /// <inheritdoc />
-        public override bool IsMatch(HttpRequestMessage request) => _predicate(request);
+        public override Task<bool> IsMatchAsync(HttpRequestMessage request)
+            => Task.FromResult(_predicate(request));
     }
 }

--- a/src/HttpClientInterception/Matching/RegistrationMatcher.cs
+++ b/src/HttpClientInterception/Matching/RegistrationMatcher.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
 
 namespace JustEat.HttpClientInterception.Matching
 {
@@ -42,7 +43,7 @@ namespace JustEat.HttpClientInterception.Matching
         }
 
         /// <inheritdoc />
-        public override bool IsMatch(HttpRequestMessage request)
+        public override async Task<bool> IsMatchAsync(HttpRequestMessage request)
         {
             if (request.RequestUri == null || request.Method != _registration.Method)
             {
@@ -56,12 +57,19 @@ namespace JustEat.HttpClientInterception.Matching
                 return false;
             }
 
+            bool isMatch = true;
+
             if (_registration.RequestHeaders != null)
             {
-                return IsMatchForHeaders(request.Headers);
+                isMatch = IsMatchForHeaders(request.Headers);
             }
 
-            return true;
+            if (isMatch && _registration.ContentMatcher != null)
+            {
+                isMatch = await _registration.ContentMatcher(request.Content).ConfigureAwait(false);
+            }
+
+            return isMatch;
         }
 
         /// <summary>

--- a/src/HttpClientInterception/Matching/RequestMatcher.cs
+++ b/src/HttpClientInterception/Matching/RequestMatcher.cs
@@ -1,7 +1,8 @@
-// Copyright (c) Just Eat, 2017. All rights reserved.
+﻿// Copyright (c) Just Eat, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace JustEat.HttpClientInterception.Matching
 {
@@ -11,12 +12,14 @@ namespace JustEat.HttpClientInterception.Matching
     internal abstract class RequestMatcher
     {
         /// <summary>
-        /// Returns a value indicating whether the specified <see cref="HttpRequestMessage"/> is considered a match.
+        /// Returns a value indicating whether the specified <see cref="HttpRequestMessage"/>
+        /// is considered a match as an asynchronous operation.
         /// </summary>
         /// <param name="request">The HTTP request to consider a match against.</param>
         /// <returns>
-        /// <see langword="true"/> if <paramref name="request"/> is considered a match; otherwise <see langword="false"/>.
+        /// A <see cref="Task{TResult}"/> that returns <see langword="true"/> if <paramref name="request"/>
+        /// is considered a match; otherwise <see langword="false"/>.
         /// </returns>
-        public abstract bool IsMatch(HttpRequestMessage request);
+        public abstract Task<bool> IsMatchAsync(HttpRequestMessage request);
     }
 }

--- a/tests/HttpClientInterception.Tests/Examples.cs
+++ b/tests/HttpClientInterception.Tests/Examples.cs
@@ -171,21 +171,23 @@ namespace JustEat.HttpClientInterception
         {
             // Arrange
             var builder = new HttpRequestInterceptionBuilder()
+                .Requests()
                 .ForPost()
                 .ForHttps()
                 .ForHost("public.je-apis.com")
                 .ForPath("consumer")
-                .WithStatus(HttpStatusCode.Created)
-                .WithContent(@"{ ""id"": 123 }")
-                .WithInterceptionCallback(
-                    async (request) =>
+                .ForContent(
+                    async (requestContent) =>
                     {
-                        string requestBody = await request.Content.ReadAsStringAsync();
+                        string requestBody = await requestContent.ReadAsStringAsync();
 
                         var body = JObject.Parse(requestBody);
 
                         return body.Value<string>("FirstName") == "John";
-                    });
+                    })
+                .Responds()
+                .WithStatus(HttpStatusCode.Created)
+                .WithContent(@"{ ""id"": 123 }");
 
             var options = new HttpClientInterceptorOptions()
                 .ThrowsOnMissingRegistration()

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -801,7 +801,7 @@ namespace JustEat.HttpClientInterception
             };
 
             var options = new HttpClientInterceptorOptions();
-            var builder = new HttpRequestInterceptionBuilder()
+            new HttpRequestInterceptionBuilder()
                 .Requests().ForPost().ForUrl(requestUri)
                 .Responds().WithFormContent(parameters)
                 .RegisterWith(options);
@@ -1093,9 +1093,8 @@ namespace JustEat.HttpClientInterception
                 .RegisterWith(options);
 
             // Change to a different scheme without an explicit port
-            builder = builder
-                .ForHttp()
-                .RegisterWith(options);
+            builder.ForHttp()
+                   .RegisterWith(options);
 
             // Act and Assert
             await HttpAssert.GetAsync(options, "http://api.github.com/orgs/justeat");
@@ -1135,10 +1134,9 @@ namespace JustEat.HttpClientInterception
                 .RegisterWith(options);
 
             // Restore default scheme and port
-            builder = builder
-                .ForHttp()
-                .ForPort(-1)
-                .RegisterWith(options);
+            builder.ForHttp()
+                   .ForPort(-1)
+                   .RegisterWith(options);
 
             // Act and Assert
             await HttpAssert.GetAsync(options, "https://api.github.com:123/orgs/justeat");
@@ -1556,6 +1554,426 @@ namespace JustEat.HttpClientInterception
 
             // Act and Assert
             Assert.Throws<ArgumentNullException>("headers", () => builder.WithResponseHeaders(headers));
+        }
+
+        [Fact]
+        public static void ForFormContent_Validates_Parameters()
+        {
+            // Arrange
+            var builder = new HttpRequestInterceptionBuilder();
+            var parameters = new Dictionary<string, string>();
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("builder", () => (null as HttpRequestInterceptionBuilder).ForFormContent(parameters));
+            Assert.Throws<ArgumentNullException>("parameters", () => builder.ForFormContent(null));
+        }
+
+        [Fact]
+        public static void ForContent_Validates_Parameters()
+        {
+            // Arrange
+            bool Predicate(HttpContent content) => false;
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("builder", () => (null as HttpRequestInterceptionBuilder).ForContent(Predicate));
+        }
+
+        [Fact]
+        public static async Task Builder_For_Posted_Encoded_Form_To_Match_Intercepts_Request()
+        {
+            // Arrange
+            // From https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html
+            var expectedForm = new Dictionary<string, string>()
+            {
+                { "Action", "SetQueueAttributes" },
+                { "Attribute.Name", "VisibilityTimeout" },
+                { "Attribute.Value", "35" },
+                { "Expires", "2020-04-18T22:52:43PST" },
+                { "Version", "2012-11-05" },
+            };
+
+            // Extra parameters to validate matches a subset
+            var actualForm = new Dictionary<string, string>()
+            {
+                { "Foo", "Bar" },
+                { "Action", "SetQueueAttributes" },
+                { "Attribute.Name", "VisibilityTimeout" },
+                { "Attribute.Value", "35" },
+                { "Expires", "2020-04-18T22:52:43PST" },
+                { "Version", "2012-11-05" },
+                { "Fizz", "Buzz" },
+            };
+
+            string expectedXml = @"<SetQueueAttributesResponse>
+    <ResponseMetadata>
+        <RequestId>e5cca473-4fc0-4198-a451-8abb94d02c75</RequestId>
+    </ResponseMetadata>
+</SetQueueAttributesResponse>";
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForHttps()
+                .ForPost()
+                .ForHost("sqs.us-east-2.amazonaws.com")
+                .ForPath("/123456789012/MyQueue/")
+                .ForFormContent(expectedForm)
+                .Responds()
+                .WithContent(expectedXml);
+
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .Register(builder);
+
+            string actualXml;
+
+            using (var client = options.CreateHttpClient())
+            {
+                // Act
+                using (var content = new FormUrlEncodedContent(actualForm))
+                {
+                    actualXml = await HttpAssert.SendAsync(
+                        options,
+                        HttpMethod.Post,
+                        "https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue/",
+                        content);
+                }
+            }
+
+            // Assert
+            actualXml.ShouldBe(expectedXml);
+        }
+
+        [Fact]
+        public static async Task Builder_For_Posted_Encoded_Form_To_Match_With_Missing_Parameter_Does_Not_Intercept_Request()
+        {
+            // Arrange
+            var actualForm = new Dictionary<string, string>()
+            {
+                { "Foo", "Bar" },
+            };
+
+            var expectedForm = new Dictionary<string, string>()
+            {
+                { "Bar", "Foo" },
+            };
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForUrl("https://test.local/form")
+                .ForPost()
+                .ForFormContent(expectedForm)
+                .Responds()
+                .WithContent("<xml/>");
+
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .Register(builder);
+
+            using (var client = options.CreateHttpClient())
+            {
+                using (var content = new FormUrlEncodedContent(actualForm))
+                {
+                    // Act
+                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
+
+                    // Assert
+                    exception.Message.ShouldStartWith("No HTTP response is configured for ");
+                }
+            }
+        }
+
+        [Fact]
+        public static async Task Builder_For_Posted_Encoded_Form_To_Match_With_Missing_Parameters_Does_Not_Intercept_Request()
+        {
+            // Arrange
+            var actualForm = new Dictionary<string, string>()
+            {
+                { "Foo", "Bar" },
+            };
+
+            var expectedForm = new Dictionary<string, string>()
+            {
+                { "Foo", "Bar" },
+                { "Baz", "Qux" },
+            };
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForUrl("https://test.local/form")
+                .ForPost()
+                .ForFormContent(expectedForm)
+                .Responds()
+                .WithContent("<xml/>");
+
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .Register(builder);
+
+            using (var client = options.CreateHttpClient())
+            {
+                using (var content = new FormUrlEncodedContent(actualForm))
+                {
+                    // Act
+                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
+
+                    // Assert
+                    exception.Message.ShouldStartWith("No HTTP response is configured for ");
+                }
+            }
+        }
+
+        [Fact]
+        public static async Task Builder_For_Posted_Encoded_Form_To_Match_With_No_Parameters_Does_Not_Intercept_Request()
+        {
+            // Arrange
+            var actualForm = new Dictionary<string, string>();
+
+            var expectedForm = new Dictionary<string, string>()
+            {
+                { "Foo", "Bar" },
+            };
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForUrl("https://test.local/form")
+                .ForPost()
+                .ForFormContent(expectedForm)
+                .Responds()
+                .WithContent("<xml/>");
+
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .Register(builder);
+
+            using (var client = options.CreateHttpClient())
+            {
+                using (var content = new FormUrlEncodedContent(actualForm))
+                {
+                    // Act
+                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
+
+                    // Assert
+                    exception.Message.ShouldStartWith("No HTTP response is configured for ");
+                }
+            }
+        }
+
+        [Fact]
+        public static async Task Builder_For_Posted_Encoded_Form_To_Match_With_Incorrect_Parameter_Does_Not_Intercept_Request()
+        {
+            // Arrange
+            var actualForm = new Dictionary<string, string>()
+            {
+                { "Foo", "Bar" },
+                { "Fizz", "Buzz" },
+            };
+
+            var expectedForm = new Dictionary<string, string>()
+            {
+                { "Foo", "Bar" },
+                { "Fizz", "Buzzz" },
+            };
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForUrl("https://test.local/form")
+                .ForPost()
+                .ForFormContent(expectedForm)
+                .Responds()
+                .WithContent("<xml/>");
+
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .Register(builder);
+
+            using (var client = options.CreateHttpClient())
+            {
+                using (var content = new FormUrlEncodedContent(actualForm))
+                {
+                    // Act
+                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
+
+                    // Assert
+                    exception.Message.ShouldStartWith("No HTTP response is configured for ");
+                }
+            }
+        }
+
+        [Fact]
+        public static async Task Builder_For_Posted_Encoded_Form_To_Match_With_Incorrect_Parameter_Case_Does_Not_Intercept_Request()
+        {
+            // Arrange
+            var expectedForm = new Dictionary<string, string>()
+            {
+                { "Foo", "Bar" },
+            };
+
+            var actualForm = new Dictionary<string, string>()
+            {
+                { "Foo", "bar" },
+            };
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForUrl("https://test.local/form")
+                .ForPost()
+                .ForFormContent(expectedForm)
+                .Responds()
+                .WithContent("<xml/>");
+
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .Register(builder);
+
+            using (var client = options.CreateHttpClient())
+            {
+                using (var content = new FormUrlEncodedContent(actualForm))
+                {
+                    // Act
+                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
+
+                    // Assert
+                    exception.Message.ShouldStartWith("No HTTP response is configured for ");
+                }
+            }
+        }
+
+        [Fact]
+        public static async Task Builder_For_Posted_Encoded_Form_To_Match_Does_Not_Intercept_Request_If_Not_Url_Encoded_Form_String()
+        {
+            // Arrange
+            var expectedForm = new Dictionary<string, string>()
+            {
+                { "Foo", "Bar" },
+            };
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForUrl("https://test.local/post")
+                .ForPost()
+                .ForFormContent(expectedForm)
+                .Responds()
+                .WithContent("<xml/>");
+
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .Register(builder);
+
+            // Act
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => HttpAssert.PostAsync(options, "https://test.local/post", new { message = "Hello" }));
+
+            // Assert
+            exception.Message.ShouldStartWith("No HTTP response is configured for ");
+        }
+
+        [Fact]
+        public static async Task Builder_For_Posted_Encoded_Form_To_Match_Does_Not_Intercept_Request_If_Not_Url_Encoded_Form_Bytes()
+        {
+            // Arrange
+            var expectedForm = new Dictionary<string, string>()
+            {
+                { "Foo", "Bar" },
+            };
+
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForUrl("https://test.local/post")
+                .ForPost()
+                .ForFormContent(expectedForm)
+                .Responds()
+                .WithContent("<xml/>");
+
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .Register(builder);
+
+            using (var stream = new MemoryStream())
+            {
+                using (var content = new StreamContent(stream))
+                {
+                    // Act
+                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/post", content));
+
+                    // Assert
+                    exception.Message.ShouldStartWith("No HTTP response is configured for ");
+                }
+            }
+        }
+
+        [Fact]
+        public static async Task Builder_ForContent_Clears_Matcher_If_Null_Synchronous()
+        {
+            // Arrange
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForUrl("https://test.local/post")
+                .ForPost()
+                .ForContent((content) => false)
+                .ForContent(null as Predicate<HttpContent>)
+                .Responds()
+                .WithContent("{}");
+
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .Register(builder);
+
+            // Act
+            string actual = await HttpAssert.PostAsync(
+                options,
+                "https://test.local/post",
+                new { });
+
+            // Assert
+            actual.ShouldBe("{}");
+        }
+
+        [Fact]
+        public static async Task Builder_ForContent_Clears_Matcher_If_Null_Asynchronous()
+        {
+            // Arrange
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForUrl("https://test.local/post")
+                .ForPost()
+                .ForContent((content) => Task.FromResult(false))
+                .ForContent(null as Func<HttpContent, Task<bool>>)
+                .Responds()
+                .WithContent("{}");
+
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .Register(builder);
+
+            // Act
+            string actual = await HttpAssert.PostAsync(
+                options,
+                "https://test.local/post",
+                new { });
+
+            // Assert
+            actual.ShouldBe("{}");
+        }
+
+        [Fact]
+        public static async Task Builder_For_Posted_Json_To_Match_Intercepts_Request()
+        {
+            // Arrange
+            var builder = new HttpRequestInterceptionBuilder()
+                .ForUrl("https://test.local/post")
+                .ForPost()
+                .ForContent((content) => content.ReadAsStringAsync().Result == @"{""message"":""Hello, Alice""}")
+                .Responds()
+                .WithJsonContent(new { message = "Hi Bob!" });
+
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .Register(builder);
+
+            // Act
+            string actual = await HttpAssert.PostAsync(
+                options,
+                "https://test.local/post",
+                new { message = "Hello, Alice" });
+
+            // Assert
+            actual.ShouldBe(@"{""message"":""Hi Bob!""}");
         }
 
         private sealed class CustomObject


### PR DESCRIPTION
  * Add support for matching requests by the request content.
  * Refactor internal matching to support async to read content from requests asynchronously.
  * Change some delegate usage to local functions.

The motivation for this change is to allow discrimination of requests to [AWS's SQS HTTP API](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Operations.html) which does HTTP POST requests to a single URL for all queue operations where the request body is an `application/x-www-form-urlencoded` payload with a parameter name of `Action` which is used to specify the operation to perform.

Without this support, it's not possible to set up interceptions correctly for a non-trivial integration (such as [JustSaying](https://github.com/justeat/JustSaying)) as the matching by URL can't discriminate between operations like [GetQueueUrl](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueUrl.html) and [ReceiveMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html) which have difference response schemas as well.
