### PR TITLE
Add async custom matching and improve exceptions for unmatched requests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{csproj,json,props,targets}]
+[*.{csproj,json,props,ruleset,targets}]
 indent_size = 2
 
 # Code files

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <VersionPrefix>2.0.2</VersionPrefix>
+    <VersionPrefix>2.0.3</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(APPVEYOR)' == 'true' AND '$(APPVEYOR_REPO_TAG)' != 'true'">beta$([System.Convert]::ToInt32(`$(APPVEYOR_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TF_BUILD)' == 'True'">beta$([System.Convert]::ToInt32(`$(BUILD_BUILDID)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TRAVIS)' == 'true'">beta$([System.Convert]::ToInt32(`$(TRAVIS_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>

--- a/HttpClientInterception.ruleset
+++ b/HttpClientInterception.ruleset
@@ -3,6 +3,7 @@
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="AD0001" Action="None" />
+    <Rule Id="CA1303" Action="None" />
     <Rule Id="SA1100" Action="None" />
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1129" Action="None" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 os: Visual Studio 2017
-version: 2.0.2.{build}
+version: 2.0.3.{build}
 
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/src/HttpClientInterception/HttpInterceptionResponse.cs
+++ b/src/HttpClientInterception/HttpInterceptionResponse.cs
@@ -14,7 +14,7 @@ namespace JustEat.HttpClientInterception
     {
         internal Func<HttpContent, Task<bool>> ContentMatcher { get; set; }
 
-        internal Predicate<HttpRequestMessage> UserMatcher { get; set; }
+        internal Func<HttpRequestMessage, Task<bool>> UserMatcher { get; set; }
 
         internal Matching.RequestMatcher InternalMatcher { get; set; }
 

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
@@ -37,7 +37,7 @@ namespace JustEat.HttpClientInterception
 
         private Func<HttpRequestMessage, Task<bool>> _onIntercepted;
 
-        private Predicate<HttpRequestMessage> _requestMatcher;
+        private Func<HttpRequestMessage, Task<bool>> _requestMatcher;
 
         private string _reasonPhrase;
 
@@ -71,6 +71,25 @@ namespace JustEat.HttpClientInterception
         /// Pass a value of <see langword="null"/> to remove a previously-registered custom request matching predicate.
         /// </remarks>
         public HttpRequestInterceptionBuilder For(Predicate<HttpRequestMessage> predicate)
+        {
+            _requestMatcher = predicate == null ? null : DelegateHelpers.ConvertToBooleanTask(predicate);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the builder to match any request that meets the criteria defined by the specified asynchronous predicate.
+        /// </summary>
+        /// <param name="predicate">
+        /// A delegate to an asynchronous method which returns <see langword="true"/> if
+        /// the request is considered a match; otherwise <see langword="false"/>.
+        /// </param>
+        /// <returns>
+        /// The current <see cref="HttpRequestInterceptionBuilder"/>.
+        /// </returns>
+        /// <remarks>
+        /// Pass a value of <see langword="null"/> to remove a previously-registered custom request matching predicate.
+        /// </remarks>
+        public HttpRequestInterceptionBuilder For(Func<HttpRequestMessage, Task<bool>> predicate)
         {
             _requestMatcher = predicate;
             return this;
@@ -675,8 +694,8 @@ namespace JustEat.HttpClientInterception
         /// </returns>
         /// <remarks>
         /// The priority is used to establish a hierarchy for matching of intercepted
-        /// HTTP requests, particularly when <see cref="For"/> is used. This allows
-        /// registered requests to establish an order of precedence when an HTTP request
+        /// HTTP requests, particularly when <see cref="For(Predicate{HttpRequestMessage})"/> is used.
+        /// This allows registered requests to establish an order of precedence when an HTTP request
         /// could match against multiple predicates, where the matching predicate with
         /// the lowest value for <paramref name="priority"/> dictates the HTTP response
         /// that is used for the intercepted request.

--- a/src/HttpClientInterception/HttpRequestNotInterceptedException.cs
+++ b/src/HttpClientInterception/HttpRequestNotInterceptedException.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Just Eat, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Http;
+#if NET461
+using System.Runtime.Serialization;
+#endif
+
+namespace JustEat.HttpClientInterception
+{
+    /// <summary>
+    /// Represents the exception when an HTTP request is made that has no interception registered. This class cannot be inherited.
+    /// </summary>
+#if !NETSTANDARD1_3
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
+#if NET461
+    [Serializable]
+#endif
+    public sealed class HttpRequestNotInterceptedException : InvalidOperationException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestNotInterceptedException"/> class.
+        /// </summary>
+        public HttpRequestNotInterceptedException()
+            : base("No HTTP response is configured for this HTTP request.")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestNotInterceptedException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public HttpRequestNotInterceptedException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestNotInterceptedException"/> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="request">The HTTP request message that was not intercepted.</param>
+        public HttpRequestNotInterceptedException(string message, HttpRequestMessage request)
+            : base(message)
+        {
+            Request = request;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestNotInterceptedException"/> class with a
+        /// specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        public HttpRequestNotInterceptedException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+#if NET461
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestNotInterceptedException"/> class with serialized data.
+        /// </summary>
+        /// <param name="serializationInfo">The object that holds the serialized object data.</param>
+        /// <param name="streamingContext">he contextual information about the source or destination.</param>
+        private HttpRequestNotInterceptedException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+            : base(serializationInfo, streamingContext)
+        {
+        }
+#endif
+
+        /// <summary>
+        /// Gets the HTTP request message that was not intercepted.
+        /// </summary>
+        public HttpRequestMessage Request { get; }
+    }
+}

--- a/src/HttpClientInterception/InterceptingHttpMessageHandler.cs
+++ b/src/HttpClientInterception/InterceptingHttpMessageHandler.cs
@@ -54,7 +54,7 @@ namespace JustEat.HttpClientInterception
                 await _options.OnSend(request).ConfigureAwait(false);
             }
 
-            HttpResponseMessage response = await _options.GetResponseAsync(request).ConfigureAwait(false);
+            var response = await _options.GetResponseAsync(request).ConfigureAwait(false);
 
             if (response == null && _options.OnMissingRegistration != null)
             {
@@ -68,7 +68,9 @@ namespace JustEat.HttpClientInterception
 
             if (_options.ThrowOnMissingRegistration)
             {
-                throw new InvalidOperationException($"No HTTP response is configured for {request.Method.Method} {request.RequestUri}.");
+                throw new HttpRequestNotInterceptedException(
+                    $"No HTTP response is configured for {request.Method.Method} {request.RequestUri}.",
+                    request);
             }
 
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);

--- a/src/HttpClientInterception/Matching/DelegatingMatcher.cs
+++ b/src/HttpClientInterception/Matching/DelegatingMatcher.cs
@@ -16,19 +16,19 @@ namespace JustEat.HttpClientInterception.Matching
         /// <summary>
         /// The user-provided predicate to use to test for a match. This field is read-only.
         /// </summary>
-        private readonly Predicate<HttpRequestMessage> _predicate;
+        private readonly Func<HttpRequestMessage, Task<bool>> _predicate;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DelegatingMatcher"/> class.
         /// </summary>
         /// <param name="predicate">The user-provided delegate to use for matching.</param>
-        internal DelegatingMatcher(Predicate<HttpRequestMessage> predicate)
+        internal DelegatingMatcher(Func<HttpRequestMessage, Task<bool>> predicate)
         {
             _predicate = predicate;
         }
 
         /// <inheritdoc />
-        public override Task<bool> IsMatchAsync(HttpRequestMessage request)
-            => Task.FromResult(_predicate(request));
+        public override async Task<bool> IsMatchAsync(HttpRequestMessage request)
+            => await _predicate(request).ConfigureAwait(false);
     }
 }

--- a/tests/HttpClientInterception.Tests/Bundles/BundleExtensionsTests.cs
+++ b/tests/HttpClientInterception.Tests/Bundles/BundleExtensionsTests.cs
@@ -382,7 +382,7 @@ namespace JustEat.HttpClientInterception.Bundles
             options.RegisterBundle(Path.Join("Bundles", "skipped-item-bundle.json"));
 
             // Assert
-            await Assert.ThrowsAsync<InvalidOperationException>(
+            await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.GetAsync(options, "https://www.just-eat.co.uk/"));
         }
 

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
@@ -409,7 +409,7 @@ namespace JustEat.HttpClientInterception
 
             options.Deregister(builder);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(() => HttpAssert.GetAsync(options, "https://bing.com/"));
+            await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(() => HttpAssert.GetAsync(options, "https://bing.com/"));
         }
 
         [Fact]
@@ -477,7 +477,7 @@ namespace JustEat.HttpClientInterception
 
             // Act and Assert
             clone.ThrowOnMissingRegistration.ShouldNotBe(options.ThrowOnMissingRegistration);
-            await Assert.ThrowsAsync<InvalidOperationException>(() => HttpAssert.GetAsync(options, url, HttpStatusCode.InternalServerError));
+            await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(() => HttpAssert.GetAsync(options, url, HttpStatusCode.InternalServerError));
             await HttpAssert.GetAsync(clone, url, HttpStatusCode.InternalServerError);
 
             // Arrange

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -952,7 +952,7 @@ namespace JustEat.HttpClientInterception
                 .Register(builder);
 
             // Act
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.PostAsync(options, requestUri.ToString(), content));
 
             // Assert
@@ -1371,7 +1371,7 @@ namespace JustEat.HttpClientInterception
             using (var client = options.CreateHttpClient())
             {
                 // Act
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                     () => client.GetStringAsync("https://public.je-apis.com/consumer/order-history"));
 
                 // Assert
@@ -1401,7 +1401,7 @@ namespace JustEat.HttpClientInterception
                 client.DefaultRequestHeaders.Add("Accept-Tenant", new[] { "ie" });
 
                 // Act
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                     () => client.GetStringAsync("https://public.je-apis.com/consumer/order-history"));
 
                 // Assert
@@ -1433,7 +1433,7 @@ namespace JustEat.HttpClientInterception
                 client.DefaultRequestHeaders.Add("Accept-Tenant", new[] { "uk" });
 
                 // Act
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                     () => client.GetStringAsync("https://public.je-apis.com/consumer/order-history"));
 
                 // Assert
@@ -1465,7 +1465,7 @@ namespace JustEat.HttpClientInterception
                 client.DefaultRequestHeaders.Add("Authorization", "basic my-other-key");
 
                 // Act
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                     () => client.GetStringAsync("https://public.je-apis.com/consumer/order-history"));
 
                 // Assert
@@ -1672,7 +1672,7 @@ namespace JustEat.HttpClientInterception
                 using (var content = new FormUrlEncodedContent(actualForm))
                 {
                     // Act
-                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                    var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                         () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
 
                     // Assert
@@ -1712,7 +1712,7 @@ namespace JustEat.HttpClientInterception
                 using (var content = new FormUrlEncodedContent(actualForm))
                 {
                     // Act
-                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                    var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                         () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
 
                     // Assert
@@ -1748,7 +1748,7 @@ namespace JustEat.HttpClientInterception
                 using (var content = new FormUrlEncodedContent(actualForm))
                 {
                     // Act
-                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                    var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                         () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
 
                     // Assert
@@ -1789,7 +1789,7 @@ namespace JustEat.HttpClientInterception
                 using (var content = new FormUrlEncodedContent(actualForm))
                 {
                     // Act
-                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                    var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                         () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
 
                     // Assert
@@ -1828,7 +1828,7 @@ namespace JustEat.HttpClientInterception
                 using (var content = new FormUrlEncodedContent(actualForm))
                 {
                     // Act
-                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                    var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                         () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
 
                     // Assert
@@ -1858,7 +1858,7 @@ namespace JustEat.HttpClientInterception
                 .Register(builder);
 
             // Act
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.PostAsync(options, "https://test.local/post", new { message = "Hello" }));
 
             // Assert
@@ -1890,7 +1890,7 @@ namespace JustEat.HttpClientInterception
                 using (var content = new StreamContent(stream))
                 {
                     // Act
-                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                    var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
                         () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/post", content));
 
                     // Assert
@@ -2055,7 +2055,8 @@ namespace JustEat.HttpClientInterception
             using (var client = options.CreateHttpClient())
             {
                 // Act and Assert
-                await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetStringAsync("https://google.com/"));
+                await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+                    () => client.GetStringAsync("https://google.com/"));
             }
         }
 

--- a/tests/HttpClientInterception.Tests/InterceptingHttpMessageHandlerTests.cs
+++ b/tests/HttpClientInterception.Tests/InterceptingHttpMessageHandlerTests.cs
@@ -37,10 +37,13 @@ namespace JustEat.HttpClientInterception
             using (var target = options.CreateHttpClient())
             {
                 // Act
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => target.GetAsync("https://google.com/"));
+                var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+                    () => target.GetAsync("https://google.com/"));
 
                 // Assert
                 exception.Message.ShouldBe("No HTTP response is configured for GET https://google.com/.");
+                exception.Request.ShouldNotBeNull();
+                exception.Request.RequestUri.ShouldBe(new Uri("https://google.com/"));
             }
         }
 
@@ -60,10 +63,13 @@ namespace JustEat.HttpClientInterception
                     using (var content = new StringContent(string.Empty))
                     {
                         // Act
-                        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => target.PostAsync("https://google.com/", content));
+                        var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+                            () => target.PostAsync("https://google.com/", content));
 
                         // Assert
                         exception.Message.ShouldBe("No HTTP response is configured for POST https://google.com/.");
+                        exception.Request.ShouldNotBeNull();
+                        exception.Request.RequestUri.ShouldBe(new Uri("https://google.com/"));
                     }
                 }
             }


### PR DESCRIPTION
  * Add a new overload for `For()` that supports asynchronous matching delegates.
  * Improve exception behaviour when a registration does not match by including the `HttpRequestMessage` in a custom derived exception. The exception derives from `InvalidOperationException` for backwards compatibility.
  * Bump package version to `2.0.3`.