### PR TITLE
Bump version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(APPVEYOR)' == 'true' AND '$(APPVEYOR_REPO_TAG)' != 'true'">beta$([System.Convert]::ToInt32(`$(APPVEYOR_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TF_BUILD)' == 'True'">beta$([System.Convert]::ToInt32(`$(BUILD_BUILDID)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TRAVIS)' == 'true'">beta$([System.Convert]::ToInt32(`$(TRAVIS_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 os: Visual Studio 2019
-version: 3.0.0.{build}
+version: 3.0.1.{build}
 
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ deploy:
 
   - provider: NuGet
     api_key:
-      secure: unyq35fj1algoC+PggYKGr/3ObnEsafyrA30JVZxk64w9Dz8G7/du5mD+UzITxHu
+      secure: KHPvV541/beC3McMmIrv2MGGlC0AxMMuc2mmqDotUw4fIhKCrKuINEkeIoh06Hsl
     artifact: /.*\.nupkg/
     skip_symbols: false
     on:


### PR DESCRIPTION
  * Bump version to 3.0.1 to prepare for a future release.
  * Update NuGet API key to publish packages.