### PR TITLE
Add time zone to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+    timezone: Europe/London
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: Microsoft.AspNetCore.WebUtilities


### PR DESCRIPTION
Add the correct time zone for Dependabot updates (see #215).
