### PR TITLE
Fix Clone()

### DIFF
--- a/HttpClientInterception.sln
+++ b/HttpClientInterception.sln
@@ -44,6 +44,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{F258
 	ProjectSection(SolutionItems) = preProject
 		.github\CODEOWNERS = .github\CODEOWNERS
 		.github\CONTRIBUTING.md = .github\CONTRIBUTING.md
+		.github\dependabot.yml = .github\dependabot.yml
 		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
 		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
 		.github\stale.yml = .github\stale.yml

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -110,6 +110,8 @@ namespace JustEat.HttpClientInterception
         {
             var clone = new HttpClientInterceptorOptions()
             {
+                OnMissingRegistration = OnMissingRegistration,
+                OnSend = OnSend,
                 ThrowOnMissingRegistration = ThrowOnMissingRegistration,
             };
 

--- a/tests/HttpClientInterception.Tests/Bundles/BundleExtensionsTests.cs
+++ b/tests/HttpClientInterception.Tests/Bundles/BundleExtensionsTests.cs
@@ -43,9 +43,9 @@ namespace JustEat.HttpClientInterception.Bundles
 
             var headers = new Dictionary<string, string>()
             {
-                { "accept", "application/vnd.github.v3+json" },
-                { "authorization", "token my-token" },
-                { "user-agent", "My-App/1.0.0" },
+                ["accept"] = "application/vnd.github.v3+json",
+                ["authorization"] = "token my-token",
+                ["user-agent"] = "My-App/1.0.0",
             };
 
             // Act
@@ -173,7 +173,7 @@ namespace JustEat.HttpClientInterception.Bundles
 
             var headers = new Dictionary<string, string>()
             {
-                { "user-agent", "My-App/1.0.0" },
+                ["user-agent"] = "My-App/1.0.0",
             };
 
             // Act
@@ -192,12 +192,12 @@ namespace JustEat.HttpClientInterception.Bundles
 
             var headers = new Dictionary<string, string>()
             {
-                { "user-agent", "My-Other-App/1.0.0" },
+                ["user-agent"] = "My-Other-App/1.0.0",
             };
 
             var templateValues = new Dictionary<string, string>()
             {
-                { "ApplicationName", "My-Other-App" },
+                ["ApplicationName"] = "My-Other-App",
             };
 
             // Act

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
@@ -238,8 +238,8 @@ namespace JustEat.HttpClientInterception
 
             var headers = new Dictionary<string, string>()
             {
-                { "a", "b" },
-                { "c", "d" },
+                ["a"] = "b",
+                ["c"] = "d",
             };
 
             var options = new HttpClientInterceptorOptions()
@@ -292,8 +292,8 @@ namespace JustEat.HttpClientInterception
 
             var responseHeaders = new Dictionary<string, IEnumerable<string>>()
             {
-                { "a", new[] { "b" } },
-                { "c", new[] { "d", "e" } },
+                ["a"] = new[] { "b" },
+                ["c"] = new[] { "d", "e" },
             };
 
             var options = new HttpClientInterceptorOptions()
@@ -322,8 +322,8 @@ namespace JustEat.HttpClientInterception
 
             var headers = new Dictionary<string, string>()
             {
-                { "a", "b" },
-                { "c", "d" },
+                ["a"] = "b",
+                ["c"] = "d",
             };
 
             var options = new HttpClientInterceptorOptions()
@@ -352,8 +352,8 @@ namespace JustEat.HttpClientInterception
 
             var responseHeaders = new Dictionary<string, IEnumerable<string>>()
             {
-                { "a", new[] { "b" } },
-                { "c", new[] { "d", "e" } },
+                ["a"] = new[] { "b" },
+                ["c"] = new[] { "d", "e" },
             };
 
             var options = new HttpClientInterceptorOptions()
@@ -714,9 +714,9 @@ namespace JustEat.HttpClientInterception
             var url = "https://api.github.com/orgs/justeat/repos?type=private";
             var headers = new Dictionary<string, string>()
             {
-                { "accept", "application/vnd.github.v3+json" },
-                { "authorization", "token my-token" },
-                { "user-agent", "My-App/1.0.0" },
+                ["accept"] = "application/vnd.github.v3+json",
+                ["authorization"] = "token my-token",
+                ["user-agent"] = "My-App/1.0.0",
             };
 
             // Act and Assert
@@ -726,9 +726,9 @@ namespace JustEat.HttpClientInterception
             // Arrange
             headers = new Dictionary<string, string>()
             {
-                { "accept", "application/vnd.github.v3+json" },
-                { "authorization", "token my-token" },
-                { "user-agent", "My-App/2.0.0" },
+                ["accept"] = "application/vnd.github.v3+json",
+                ["authorization"] = "token my-token",
+                ["user-agent"] = "My-App/2.0.0",
             };
 
             // Act and Assert
@@ -737,8 +737,8 @@ namespace JustEat.HttpClientInterception
             // Arrange
             headers = new Dictionary<string, string>()
             {
-                { "accept", "application/vnd.github.v3+json" },
-                { "user-agent", "My-App/1.0.0" },
+                ["accept"] = "application/vnd.github.v3+json",
+                ["user-agent"] = "My-App/1.0.0",
             };
 
             // Act and Assert

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
@@ -468,16 +468,24 @@ namespace JustEat.HttpClientInterception
                 .RegisterGetJson(url, payload, statusCode: HttpStatusCode.InternalServerError);
 
             // Assert
+            clone.OnMissingRegistration.ShouldBe(options.OnMissingRegistration);
+            clone.OnSend.ShouldBe(options.OnSend);
             clone.ThrowOnMissingRegistration.ShouldBe(options.ThrowOnMissingRegistration);
+
             await HttpAssert.GetAsync(options, url, HttpStatusCode.NotFound);
             await HttpAssert.GetAsync(clone, url, HttpStatusCode.InternalServerError);
 
             // Arrange
+            options.OnMissingRegistration = (_) => Task.FromResult<HttpResponseMessage>(null);
+            options.OnSend = (_) => Task.CompletedTask;
             options.ThrowOnMissingRegistration = true;
             options.Clear();
 
             // Act and Assert
             clone.ThrowOnMissingRegistration.ShouldNotBe(options.ThrowOnMissingRegistration);
+            clone.OnMissingRegistration.ShouldNotBe(options.OnMissingRegistration);
+            clone.OnSend.ShouldNotBe(options.OnSend);
+
             await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(() => HttpAssert.GetAsync(options, url, HttpStatusCode.InternalServerError));
             await HttpAssert.GetAsync(clone, url, HttpStatusCode.InternalServerError);
 
@@ -490,6 +498,8 @@ namespace JustEat.HttpClientInterception
 
             // Assert
             clone.ThrowOnMissingRegistration.ShouldBe(options.ThrowOnMissingRegistration);
+            clone.OnMissingRegistration.ShouldBe(options.OnMissingRegistration);
+            clone.OnSend.ShouldBe(options.OnSend);
         }
 
         [Fact]

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -404,8 +404,8 @@ namespace JustEat.HttpClientInterception
 
             var headers = new Dictionary<string, string>()
             {
-                { "a", "b" },
-                { "c", "d" },
+                ["a"] = "b",
+                ["c"] = "d",
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -434,8 +434,8 @@ namespace JustEat.HttpClientInterception
 
             var headers = new Dictionary<string, ICollection<string>>()
             {
-                { "a", new[] { "b" } },
-                { "c", new[] { "d", "e" } },
+                ["a"] = new[] { "b" },
+                ["c"] = new[] { "d", "e" },
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -490,8 +490,8 @@ namespace JustEat.HttpClientInterception
 
             var headers = new Dictionary<string, string>()
             {
-                { "a", "b" },
-                { "c", "d" },
+                ["a"] = "b",
+                ["c"] = "d",
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -520,8 +520,8 @@ namespace JustEat.HttpClientInterception
 
             var headers = new Dictionary<string, ICollection<string>>()
             {
-                { "a", new[] { "b" } },
-                { "c", new[] { "d", "e" } },
+                ["a"] = new[] { "b" },
+                ["c"] = new[] { "d", "e" },
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -860,9 +860,9 @@ namespace JustEat.HttpClientInterception
             var requestUri = "https://api.twitter.com/oauth/request_token";
             var parameters = new Dictionary<string, string>()
             {
-                { "oauth_callback_confirmed", "true" },
-                { "oauth_token", "a b c" },
-                { "oauth_token_secret", "U5LJUL3eS+fl9bj9xqHKXyHpBc8=" },
+                ["oauth_callback_confirmed"] = "true",
+                ["oauth_token"] = "a b c",
+                ["oauth_token_secret"] = "U5LJUL3eS+fl9bj9xqHKXyHpBc8=",
             };
 
             var options = new HttpClientInterceptorOptions();
@@ -1450,8 +1450,8 @@ namespace JustEat.HttpClientInterception
             // Arrange
             var headers = new Dictionary<string, string>()
             {
-                { "Accept-Tenant", "uk" },
-                { "Authorization", "basic my-key" },
+                ["Accept-Tenant"] = "uk",
+                ["Authorization"] = "basic my-key",
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -1552,8 +1552,8 @@ namespace JustEat.HttpClientInterception
             // Arrange
             var headers = new Dictionary<string, ICollection<string>>()
             {
-                { "x-forwarded-for", new[] { "192.168.1.1", "192.168.1.2" } },
-                { "x-forwarded-proto", new[] { "http", "https" } },
+                ["x-forwarded-for"] = new[] { "192.168.1.1", "192.168.1.2" },
+                ["x-forwarded-proto"] = new[] { "http", "https" },
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -1807,23 +1807,23 @@ namespace JustEat.HttpClientInterception
             // From https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html
             var expectedForm = new Dictionary<string, string>()
             {
-                { "Action", "SetQueueAttributes" },
-                { "Attribute.Name", "VisibilityTimeout" },
-                { "Attribute.Value", "35" },
-                { "Expires", "2020-04-18T22:52:43PST" },
-                { "Version", "2012-11-05" },
+                ["Action"] = "SetQueueAttributes",
+                ["Attribute.Name"] = "VisibilityTimeout",
+                ["Attribute.Value"] = "35",
+                ["Expires"] = "2020-04-18T22:52:43PST",
+                ["Version"] = "2012-11-05",
             };
 
             // Extra parameters to validate matches a subset
             var actualForm = new Dictionary<string, string>()
             {
-                { "Foo", "Bar" },
-                { "Action", "SetQueueAttributes" },
-                { "Attribute.Name", "VisibilityTimeout" },
-                { "Attribute.Value", "35" },
-                { "Expires", "2020-04-18T22:52:43PST" },
-                { "Version", "2012-11-05" },
-                { "Fizz", "Buzz" },
+                ["Foo"] = "Bar",
+                ["Action"] = "SetQueueAttributes",
+                ["Attribute.Name"] = "VisibilityTimeout",
+                ["Attribute.Value"] = "35",
+                ["Expires"] = "2020-04-18T22:52:43PST",
+                ["Version"] = "2012-11-05",
+                ["Fizz"] = "Buzz",
             };
 
             string expectedXml = @"<SetQueueAttributesResponse>
@@ -1868,12 +1868,12 @@ namespace JustEat.HttpClientInterception
             // Arrange
             var actualForm = new Dictionary<string, string>()
             {
-                { "Foo", "Bar" },
+                ["Foo"] = "Bar",
             };
 
             var expectedForm = new Dictionary<string, string>()
             {
-                { "Bar", "Foo" },
+                ["Bar"] = "Foo",
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -1904,13 +1904,13 @@ namespace JustEat.HttpClientInterception
             // Arrange
             var actualForm = new Dictionary<string, string>()
             {
-                { "Foo", "Bar" },
+                ["Foo"] = "Bar",
             };
 
             var expectedForm = new Dictionary<string, string>()
             {
-                { "Foo", "Bar" },
-                { "Baz", "Qux" },
+                ["Foo"] = "Bar",
+                ["Baz"] = "Qux",
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -1943,7 +1943,7 @@ namespace JustEat.HttpClientInterception
 
             var expectedForm = new Dictionary<string, string>()
             {
-                { "Foo", "Bar" },
+                ["Foo"] = "Bar",
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -1974,14 +1974,14 @@ namespace JustEat.HttpClientInterception
             // Arrange
             var actualForm = new Dictionary<string, string>()
             {
-                { "Foo", "Bar" },
-                { "Fizz", "Buzz" },
+                ["Foo"] = "Bar",
+                ["Fizz"] = "Buzz",
             };
 
             var expectedForm = new Dictionary<string, string>()
             {
-                { "Foo", "Bar" },
-                { "Fizz", "Buzzz" },
+                ["Foo"] = "Bar",
+                ["Fizz"] = "Buzzz",
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -2012,12 +2012,12 @@ namespace JustEat.HttpClientInterception
             // Arrange
             var expectedForm = new Dictionary<string, string>()
             {
-                { "Foo", "Bar" },
+                ["Foo"] = "Bar",
             };
 
             var actualForm = new Dictionary<string, string>()
             {
-                { "Foo", "bar" },
+                ["Foo"] = "bar",
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -2048,7 +2048,7 @@ namespace JustEat.HttpClientInterception
             // Arrange
             var expectedForm = new Dictionary<string, string>()
             {
-                { "Foo", "Bar" },
+                ["Foo"] = "Bar",
             };
 
             var builder = new HttpRequestInterceptionBuilder()
@@ -2076,7 +2076,7 @@ namespace JustEat.HttpClientInterception
             // Arrange
             var expectedForm = new Dictionary<string, string>()
             {
-                { "Foo", "Bar" },
+                ["Foo"] = "Bar",
             };
 
             var builder = new HttpRequestInterceptionBuilder()


### PR DESCRIPTION
  * Fix the `OnMissingRegistration` and `OnSend` properties not being copied on the returned instance from calls to `Clone()`.
  * Use the newer dictionary syntax in the tests.
  * Add the dependabot configuration file to the solution items.