### PR TITLE
Add example of testing rate limiting

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Moq" Version="4.14.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="3.0.13" />
+    <PackageVersion Include="Polly" Version="7.2.1" />
     <PackageVersion Include="Refit" Version="5.2.1" />
     <PackageVersion Include="ReportGenerator" Version="4.6.7" />
     <PackageVersion Include="Shouldly" Version="3.0.2" />

--- a/tests/HttpClientInterception.Tests/Examples.cs
+++ b/tests/HttpClientInterception.Tests/Examples.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JustEat.HttpClientInterception.GitHub;
 using Newtonsoft.Json.Linq;
+using Polly;
 using Refit;
 using Shouldly;
 using Xunit;
@@ -666,6 +667,67 @@ namespace JustEat.HttpClientInterception
 
             // Assert
             cts.IsCancellationRequested.ShouldBeTrue();
+        }
+
+        [Fact]
+        public static async Task Simulate_Http_Rate_Limiting()
+        {
+            // Arrange
+            var options = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration();
+
+            // Keep track of how many HTTP requests to GitHub have been made
+            int count = 0;
+
+            static bool IsHttpGetForJustEatGitHubOrg(HttpRequestMessage request)
+            {
+                return
+                    request.Method.Equals(HttpMethod.Get) &&
+                    request.RequestUri == new Uri("https://api.github.com/orgs/justeat");
+            }
+
+            // Register an HTTP 429 error with a specified priority. The For() delegate
+            // is used to match invocation counts that are not divisible by three so that
+            // the first, second, fourth, fifth, seventh etc. request returns an error.
+            var builder1 = new HttpRequestInterceptionBuilder()
+                .For((request) => IsHttpGetForJustEatGitHubOrg(request) && ++count % 3 != 0)
+                .HavingPriority(0)
+                .Responds()
+                .WithStatus(HttpStatusCode.TooManyRequests)
+                .WithSystemTextJsonContent(new { message = "Too many requests" })
+                .RegisterWith(options);
+
+            // Register another request for an HTTP 200 with no priority that will match
+            // if the higher-priority for the HTTP 429 response does not match the request.
+            // In practice this will match for the third, sixth, ninth etc. request.
+            var builder2 = new HttpRequestInterceptionBuilder()
+                .For(IsHttpGetForJustEatGitHubOrg)
+                .Responds()
+                .WithStatus(HttpStatusCode.OK)
+                .WithSystemTextJsonContent(new { id = 1516790, login = "justeat", url = "https://api.github.com/orgs/justeat" })
+                .RegisterWith(options);
+
+            var service = RestService.For<IGitHub>(options.CreateHttpClient("https://api.github.com"));
+
+            // Configure a Polly retry policy that will retry an HTTP request up to three times
+            // if the HTTP request fails due to an HTTP 429 response from the server.
+            int retryCount = 3;
+
+            var policy = Policy
+                .Handle<ApiException>((ex) => ex.StatusCode == HttpStatusCode.TooManyRequests)
+                .RetryAsync(retryCount);
+
+            // Act
+            Organization actual = await policy.ExecuteAsync(() => service.GetOrganizationAsync("justeat"));
+
+            // Assert
+            actual.ShouldNotBeNull();
+            actual.Id.ShouldBe("1516790");
+            actual.Login.ShouldBe("justeat");
+            actual.Url.ShouldBe("https://api.github.com/orgs/justeat");
+
+            // Verify that the expected number of attempts were made
+            count.ShouldBe(retryCount);
         }
     }
 }

--- a/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
+++ b/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Newtonsoft.Json.Schema" />
+    <PackageReference Include="Polly" />
     <PackageReference Include="Refit" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
Add an example of using Polly and Refit to test rate-limiting behaviour.

It's quite verbose and took me a while to come up with, so there's some API functionality missing to make this sort of thing a lot easier without having to drop to too low-level an API.

Relates to #247.
