### PR TITLE
Enable deterministic builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <Company>Just Eat</Company>
     <ContinuousIntegrationBuild Condition=" '$(CI)' != '' ">true</ContinuousIntegrationBuild>
     <Copyright>Copyright (c) Just Eat 2017-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
-    <Deterministic>false</Deterministic>
+    <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.103",
+    "version": "5.0.201",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }


### PR DESCRIPTION
Enable deterministic builds and update to the latest .NET SDK.