### PR TITLE
Ignore artifacts directory

### DIFF
--- a/.github/workflows/on-push-do-docs.yml
+++ b/.github/workflows/on-push-do-docs.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Run MarkdownSnippets
       run: |
         dotnet tool install --global MarkdownSnippets.Tool
-        mdsnippets "${GITHUB_WORKSPACE}"
+        mdsnippets "${GITHUB_WORKSPACE}" --exclude-directories ./artifacts
       shell: bash
       env:
         DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/mdsnippets.json
+++ b/mdsnippets.json
@@ -1,3 +1,4 @@
 ﻿{
-  "Convention": "InPlaceOverwrite"
+  "Convention": "InPlaceOverwrite",
+  "ExcludeDirectories": [ "artifacts" ]
 }


### PR DESCRIPTION
Ignore the `artifacts` directory when updating the snippets as otherwise incorrect documentation is generated.
