### PR TITLE
Rewrote acting and assertion step of tests by Shouldly when using 'Assert.Throws'

### DIFF
--- a/tests/HttpClientInterception.Tests/Bundles/BundleExtensionsTests.cs
+++ b/tests/HttpClientInterception.Tests/Bundles/BundleExtensionsTests.cs
@@ -262,9 +262,9 @@ namespace JustEat.HttpClientInterception.Bundles
             string path = "foo.bar";
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("options", () => ((HttpClientInterceptorOptions)null).RegisterBundle(path));
-            Assert.Throws<ArgumentNullException>("path", () => options.RegisterBundle(null));
-            Assert.Throws<ArgumentNullException>("templateValues", () => options.RegisterBundle(path, null));
+            Should.Throw<ArgumentNullException>(() => ((HttpClientInterceptorOptions)null).RegisterBundle(path), "options");
+            Should.Throw<ArgumentNullException>(() => options.RegisterBundle(null), "path");
+            Should.Throw<ArgumentNullException>(() => options.RegisterBundle(path, null), "templateValues");
         }
 
         [Fact]
@@ -275,7 +275,7 @@ namespace JustEat.HttpClientInterception.Bundles
             string path = Path.Join("Bundles", "invalid-bundle-version.json");
 
             // Act and Assert
-            Assert.Throws<NotSupportedException>(() => options.RegisterBundle(path));
+            Should.Throw<NotSupportedException>(() => options.RegisterBundle(path));
         }
 
         [Fact]
@@ -297,7 +297,7 @@ namespace JustEat.HttpClientInterception.Bundles
             string path = Path.Join("Bundles", "invalid-content-format.json");
 
             // Act and Assert
-            var exception = Assert.Throws<NotSupportedException>(() => options.RegisterBundle(path));
+            var exception = Should.Throw<NotSupportedException>(() => options.RegisterBundle(path));
             exception.Message.ShouldBe("Content format 'foo' for bundle item with Id 'invalid-content-format' is not supported.");
         }
 
@@ -309,7 +309,7 @@ namespace JustEat.HttpClientInterception.Bundles
             string path = Path.Join("Bundles", "invalid-status-code.json");
 
             // Act and Assert
-            var exception = Assert.Throws<InvalidOperationException>(() => options.RegisterBundle(path));
+            var exception = Should.Throw<InvalidOperationException>(() => options.RegisterBundle(path));
             exception.Message.ShouldBe("Bundle item with Id 'invalid-status' has an invalid HTTP status code 'foo' configured.");
         }
 
@@ -321,7 +321,7 @@ namespace JustEat.HttpClientInterception.Bundles
             string path = Path.Join("Bundles", "invalid-uri.json");
 
             // Act and Assert
-            var exception = Assert.Throws<InvalidOperationException>(() => options.RegisterBundle(path));
+            var exception = Should.Throw<InvalidOperationException>(() => options.RegisterBundle(path));
             exception.Message.ShouldBe("Bundle item with Id 'invalid-uri' has an invalid absolute URI '::invalid' configured.");
         }
 
@@ -333,7 +333,7 @@ namespace JustEat.HttpClientInterception.Bundles
             string path = Path.Join("Bundles", "invalid-version.json");
 
             // Act and Assert
-            var exception = Assert.Throws<InvalidOperationException>(() => options.RegisterBundle(path));
+            var exception = Should.Throw<InvalidOperationException>(() => options.RegisterBundle(path));
             exception.Message.ShouldBe("Bundle item with Id 'invalid-version' has an invalid version 'foo' configured.");
         }
 
@@ -345,7 +345,7 @@ namespace JustEat.HttpClientInterception.Bundles
             string path = Path.Join("Bundles", "no-uri.json");
 
             // Act and Assert
-            var exception = Assert.Throws<InvalidOperationException>(() => options.RegisterBundle(path));
+            var exception = Should.Throw<InvalidOperationException>(() => options.RegisterBundle(path));
             exception.Message.ShouldBe("Bundle item with Id 'no-uri' has no URI configured.");
         }
 
@@ -411,7 +411,7 @@ namespace JustEat.HttpClientInterception.Bundles
             options.RegisterBundle(Path.Join("Bundles", "skipped-item-bundle.json"));
 
             // Assert
-            await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.GetAsync(options, "https://www.just-eat.co.uk/"));
         }
 

--- a/tests/HttpClientInterception.Tests/Examples.cs
+++ b/tests/HttpClientInterception.Tests/Examples.cs
@@ -38,7 +38,7 @@ namespace JustEat.HttpClientInterception
             var client = options.CreateHttpClient();
 
             // Throws an HttpRequestException
-            await Assert.ThrowsAsync<HttpRequestException>(
+            await Should.ThrowAsync<HttpRequestException>(
                 () => client.GetStringAsync("http://public.je-apis.com"));
 
             // end-snippet
@@ -695,7 +695,7 @@ namespace JustEat.HttpClientInterception
             using var client = options.CreateHttpClient();
 
             // Act
-            await Assert.ThrowsAsync<TaskCanceledException>(
+            await Should.ThrowAsync<TaskCanceledException>(
                 () => client.GetAsync("http://www.google.co.uk", cts.Token));
 
             // Assert

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsExtensionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsExtensionsTests.cs
@@ -36,13 +36,13 @@ namespace JustEat.HttpClientInterception
             HttpClientInterceptorOptions options = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("options", () => options.RegisterGetJson("https://google.com", new { }));
+            Should.Throw<ArgumentNullException>(() => options.RegisterGetJson("https://google.com", new { }), "content");
 
             // Arrange
             options = new HttpClientInterceptorOptions();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("content", () => options.RegisterGetJson("https://google.com", null));
+            Should.Throw<ArgumentNullException>(() => options.RegisterGetJson("https://google.com", null), "content");
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace JustEat.HttpClientInterception
             HttpClientInterceptorOptions options = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("options", () => options.RegisterGet("https://google.com", string.Empty));
+            Should.Throw<ArgumentNullException>(() => options.RegisterGet("https://google.com", string.Empty), "options");
         }
 
         [Fact]
@@ -112,7 +112,7 @@ namespace JustEat.HttpClientInterception
             HttpClientInterceptorOptions options = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("options", () => options.DeregisterGet("https://google.com"));
+            Should.Throw<ArgumentNullException>(() => options.DeregisterGet("https://google.com"), "options");
         }
 
         [Fact]
@@ -126,9 +126,7 @@ namespace JustEat.HttpClientInterception
             IEnumerable<KeyValuePair<string, string>> headers = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>(
-                "options",
-                () => options.RegisterByteArray(method, uri, contentFactory: Array.Empty<byte>, responseHeaders: headers));
+            Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory: Array.Empty<byte>, responseHeaders: headers), "options");
         }
 
         [Fact]
@@ -141,9 +139,7 @@ namespace JustEat.HttpClientInterception
             HttpClientInterceptorOptions options = null;
             IEnumerable<KeyValuePair<string, string>> headers = null;
 
-            Assert.Throws<ArgumentNullException>(
-                "options",
-                () => options.RegisterStream(method, uri, contentStream: () => Stream.Null, responseHeaders: headers));
+            Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream: () => Stream.Null, responseHeaders: headers), "options");
         }
 
         [Fact]
@@ -155,7 +151,7 @@ namespace JustEat.HttpClientInterception
             HttpClientInterceptorOptions options = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("options", () => options.CreateHttpClient(baseAddress));
+            Should.Throw<ArgumentNullException>(() => options.CreateHttpClient(baseAddress), "options");
         }
 
         [Fact]
@@ -167,7 +163,7 @@ namespace JustEat.HttpClientInterception
             HttpClientInterceptorOptions options = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("options", () => options.Register(new List<HttpRequestInterceptionBuilder>()));
+            Should.Throw<ArgumentNullException>(() => options.Register(new List<HttpRequestInterceptionBuilder>()), "options");
         }
 
         [Fact]
@@ -180,7 +176,7 @@ namespace JustEat.HttpClientInterception
             IEnumerable<HttpRequestInterceptionBuilder> collection = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("collection", () => options.Register(collection));
+            Should.Throw<ArgumentNullException>(() => options.Register(collection), "collection");
         }
 
         [Fact]
@@ -224,7 +220,7 @@ namespace JustEat.HttpClientInterception
             HttpClientInterceptorOptions options = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("options", () => options.Register(Array.Empty<HttpRequestInterceptionBuilder>()));
+            Should.Throw<ArgumentNullException>(() => options.Register(Array.Empty<HttpRequestInterceptionBuilder>()), "options");
         }
 
         [Fact]
@@ -237,7 +233,7 @@ namespace JustEat.HttpClientInterception
             HttpRequestInterceptionBuilder[] collection = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("collection", () => options.Register(collection));
+            Should.Throw<ArgumentNullException>(() => options.Register(collection), "collection");
         }
 
         [Fact]
@@ -279,7 +275,7 @@ namespace JustEat.HttpClientInterception
             HttpClientInterceptorOptions options = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("options", () => options.ThrowsOnMissingRegistration());
+            Should.Throw<ArgumentNullException>(() => options.ThrowsOnMissingRegistration(), "options");
         }
 
         [Fact]

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsExtensionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsExtensionsTests.cs
@@ -36,7 +36,7 @@ namespace JustEat.HttpClientInterception
             HttpClientInterceptorOptions options = null;
 
             // Act and Assert
-            Should.Throw<ArgumentNullException>(() => options.RegisterGetJson("https://google.com", new { }), "content");
+            Should.Throw<ArgumentNullException>(() => options.RegisterGetJson("https://google.com", new { }), "options");
 
             // Arrange
             options = new HttpClientInterceptorOptions();

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
@@ -392,8 +392,8 @@ namespace JustEat.HttpClientInterception
                    .DeregisterGet("https://google.com/");
 
             // Act and Assert
-            await Assert.ThrowsAsync<HttpRequestException>(() => HttpAssert.GetAsync(options, "https://google.com/"));
-            await Assert.ThrowsAsync<HttpRequestException>(() => HttpAssert.GetAsync(options, "https://google.com/"));
+            await Should.ThrowAsync<HttpRequestException>(() => HttpAssert.GetAsync(options, "https://google.com/"));
+            await Should.ThrowAsync<HttpRequestException>(() => HttpAssert.GetAsync(options, "https://google.com/"));
             await HttpAssert.GetAsync(options, "https://google.co.uk/");
             await HttpAssert.GetAsync(options, "https://google.co.uk/");
 
@@ -410,7 +410,7 @@ namespace JustEat.HttpClientInterception
 
             options.Deregister(builder);
 
-            await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(() => HttpAssert.GetAsync(options, "https://bing.com/"));
+            await Should.ThrowAsync<HttpRequestNotInterceptedException>(() => HttpAssert.GetAsync(options, "https://bing.com/"));
         }
 
         [Fact]
@@ -486,7 +486,7 @@ namespace JustEat.HttpClientInterception
             clone.OnMissingRegistration.ShouldNotBe(options.OnMissingRegistration);
             clone.OnSend.ShouldNotBe(options.OnSend);
 
-            await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(() => HttpAssert.GetAsync(options, url, HttpStatusCode.InternalServerError));
+            await Should.ThrowAsync<HttpRequestNotInterceptedException>(() => HttpAssert.GetAsync(options, url, HttpStatusCode.InternalServerError));
             await HttpAssert.GetAsync(clone, url, HttpStatusCode.InternalServerError);
 
             // Arrange
@@ -512,7 +512,7 @@ namespace JustEat.HttpClientInterception
             Uri uri = new Uri("https://www.just-eat.co.uk");
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("method", () => options.Deregister(method, uri));
+            Should.Throw<ArgumentNullException>(() => options.Deregister(method, uri), "method");
         }
 
         [Fact]
@@ -525,7 +525,7 @@ namespace JustEat.HttpClientInterception
             Uri uri = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("uri", () => options.Deregister(method, uri));
+            Should.Throw<ArgumentNullException>(() => options.Deregister(method, uri), "uri");
         }
 
         [Fact]
@@ -537,7 +537,7 @@ namespace JustEat.HttpClientInterception
             HttpRequestInterceptionBuilder builder = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => options.Deregister(builder));
+            Should.Throw<ArgumentNullException>(() => options.Deregister(builder), "builder");
         }
 
         [Fact]
@@ -550,7 +550,7 @@ namespace JustEat.HttpClientInterception
             Uri uri = new Uri("https://www.just-eat.co.uk");
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("method", () => options.RegisterByteArray(method, uri, contentFactory: EmptyContent));
+            Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory: EmptyContent), "method");
         }
 
         [Fact]
@@ -563,7 +563,7 @@ namespace JustEat.HttpClientInterception
             var uri = new Uri("https://www.just-eat.co.uk");
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("method", () => options.RegisterStream(method, uri, contentStream: EmptyStream));
+            Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream: EmptyStream), "method");
         }
 
         [Fact]
@@ -576,7 +576,7 @@ namespace JustEat.HttpClientInterception
             Uri uri = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("uri", () => options.RegisterByteArray(method, uri, contentFactory: EmptyContent));
+            Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory: EmptyContent), "uri");
         }
 
         [Fact]
@@ -589,7 +589,7 @@ namespace JustEat.HttpClientInterception
             Uri uri = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("uri", () => options.RegisterStream(method, uri, contentStream: EmptyStream));
+            Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream: EmptyStream), "uri");
         }
 
         [Fact]
@@ -603,7 +603,7 @@ namespace JustEat.HttpClientInterception
             Func<byte[]> contentFactory = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("contentFactory", () => options.RegisterByteArray(method, uri, contentFactory));
+            Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory), "contentFactory");
         }
 
         [Fact]
@@ -617,7 +617,7 @@ namespace JustEat.HttpClientInterception
             Func<Task<byte[]>> contentFactory = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("contentFactory", () => options.RegisterByteArray(method, uri, contentFactory));
+            Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory), "contentFactory");
         }
 
         [Fact]
@@ -631,7 +631,7 @@ namespace JustEat.HttpClientInterception
             Func<Stream> contentStream = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("contentStream", () => options.RegisterStream(method, uri, contentStream));
+            Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream), "contentStream");
         }
 
         [Fact]
@@ -645,7 +645,7 @@ namespace JustEat.HttpClientInterception
             Func<Task<Stream>> contentStream = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("contentStream", () => options.RegisterStream(method, uri, contentStream));
+            Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream), "contentStream");
         }
 
         [Fact]
@@ -656,7 +656,7 @@ namespace JustEat.HttpClientInterception
             HttpRequestMessage request = null;
 
             // Act and Assert
-            await Assert.ThrowsAsync<ArgumentNullException>("request", () => options.GetResponseAsync(request));
+            await Should.ThrowAsync<ArgumentNullException>(() => options.GetResponseAsync(request), "request");
         }
 
         [Fact]
@@ -667,7 +667,7 @@ namespace JustEat.HttpClientInterception
             HttpRequestInterceptionBuilder builder = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => options.Register(builder));
+            Should.Throw<ArgumentNullException>(() => options.Register(builder), "builder");
         }
 
         [Fact]
@@ -683,7 +683,7 @@ namespace JustEat.HttpClientInterception
             using var request = new HttpRequestMessage(method, uri);
 
             // Act and Assert
-            await Assert.ThrowsAsync<NotImplementedException>(() => options.GetResponseAsync(request));
+            await Should.ThrowAsync<NotImplementedException>(() => options.GetResponseAsync(request));
         }
 
         [Fact]
@@ -699,7 +699,7 @@ namespace JustEat.HttpClientInterception
             using var request = new HttpRequestMessage(method, uri);
 
             // Act and Assert
-            await Assert.ThrowsAsync<NotImplementedException>(() => options.GetResponseAsync(request));
+            await Should.ThrowAsync<NotImplementedException>(() => options.GetResponseAsync(request));
         }
 
         [Fact]
@@ -731,7 +731,7 @@ namespace JustEat.HttpClientInterception
 
             // Act and Assert
             await HttpAssert.GetAsync(options, url, headers: headers);
-            await Assert.ThrowsAsync<HttpRequestException>(() => HttpAssert.GetAsync(options, url));
+            await Should.ThrowAsync<HttpRequestException>(() => HttpAssert.GetAsync(options, url));
 
             // Arrange
             headers = new Dictionary<string, string>()
@@ -742,7 +742,7 @@ namespace JustEat.HttpClientInterception
             };
 
             // Act and Assert
-            await Assert.ThrowsAsync<HttpRequestException>(() => HttpAssert.GetAsync(options, url, headers: headers));
+            await Should.ThrowAsync<HttpRequestException>(() => HttpAssert.GetAsync(options, url, headers: headers));
 
             // Arrange
             headers = new Dictionary<string, string>()
@@ -752,7 +752,7 @@ namespace JustEat.HttpClientInterception
             };
 
             // Act and Assert
-            await Assert.ThrowsAsync<HttpRequestException>(() => HttpAssert.GetAsync(options, url, headers: headers));
+            await Should.ThrowAsync<HttpRequestException>(() => HttpAssert.GetAsync(options, url, headers: headers));
         }
 
         private static Task<byte[]> EmptyContent() => Task.FromResult(Array.Empty<byte>());

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -655,7 +655,7 @@ namespace JustEat.HttpClientInterception
             options.Register(builder);
 
             // Assert
-            await Assert.ThrowsAsync<HttpRequestException>(() =>
+            await Should.ThrowAsync<HttpRequestException>(() =>
                 HttpAssert.GetAsync(options, "http://something.com/path/1234"));
         }
 
@@ -691,7 +691,7 @@ namespace JustEat.HttpClientInterception
             options.Register(builder);
 
             // Assert
-            await Assert.ThrowsAsync<HttpRequestException>(() =>
+            await Should.ThrowAsync<HttpRequestException>(() =>
                 HttpAssert.GetAsync(options, "http://something.com?query=1234"));
         }
 
@@ -838,7 +838,7 @@ namespace JustEat.HttpClientInterception
         public static void WithContent_Validates_Parameters()
         {
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).WithContent((string)null));
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithContent((string)null), "builder");
         }
 
         [Fact]
@@ -849,8 +849,8 @@ namespace JustEat.HttpClientInterception
             IEnumerable<KeyValuePair<string, string>> parameters = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).WithFormContent(parameters));
-            Assert.Throws<ArgumentNullException>("parameters", () => builder.WithFormContent(parameters));
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithFormContent(parameters), "builder");
+            Should.Throw<ArgumentNullException>(() => builder.WithFormContent(parameters), "parameters");
         }
 
         [Fact]
@@ -886,8 +886,8 @@ namespace JustEat.HttpClientInterception
             object content = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).WithJsonContent(content));
-            Assert.Throws<ArgumentNullException>("content", () => builder.WithJsonContent(content));
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithJsonContent(content), "builder");
+            Should.Throw<ArgumentNullException>(() => builder.WithJsonContent(content), "content");
         }
 
         [Fact]
@@ -898,8 +898,8 @@ namespace JustEat.HttpClientInterception
             object content = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).WithNewtonsoftJsonContent(content));
-            Assert.Throws<ArgumentNullException>("content", () => builder.WithNewtonsoftJsonContent(content));
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithNewtonsoftJsonContent(content), "builder");
+            Should.Throw<ArgumentNullException>(() => builder.WithNewtonsoftJsonContent(content), "content");
         }
 
         [Fact]
@@ -910,8 +910,8 @@ namespace JustEat.HttpClientInterception
             object content = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).WithSystemTextJsonContent(content));
-            Assert.Throws<ArgumentNullException>("content", () => builder.WithSystemTextJsonContent(content));
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithSystemTextJsonContent(content), "builder");
+            Should.Throw<ArgumentNullException>(() => builder.WithSystemTextJsonContent(content), "content");
         }
 
         [Fact]
@@ -921,49 +921,49 @@ namespace JustEat.HttpClientInterception
             string uriString = "https://google.com/";
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).ForUrl(uriString));
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForUrl(uriString), "builder");
         }
 
         [Fact]
         public static void ForDelete_Validates_Parameters()
         {
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).ForDelete());
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForDelete(), "builder");
         }
 
         [Fact]
         public static void ForGet_Validates_Parameters()
         {
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).ForGet());
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForGet(), "builder");
         }
 
         [Fact]
         public static void ForPost_Validates_Parameters()
         {
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).ForPost());
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForPost(), "builder");
         }
 
         [Fact]
         public static void ForPut_Validates_Parameters()
         {
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).ForPut());
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForPut(), "builder");
         }
 
         [Fact]
         public static void ForHttp_Validates_Parameters()
         {
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).ForHttp());
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForHttp(), "builder");
         }
 
         [Fact]
         public static void ForHttps_Validates_Parameters()
         {
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).ForHttps());
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForHttps(), "builder");
         }
 
         [Fact]
@@ -973,7 +973,7 @@ namespace JustEat.HttpClientInterception
             HttpRequestInterceptionBuilder builder = new HttpRequestInterceptionBuilder();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("method", () => builder.ForMethod(null));
+            Should.Throw<ArgumentNullException>(() => builder.ForMethod(null), "method");
         }
 
         [Fact]
@@ -984,7 +984,7 @@ namespace JustEat.HttpClientInterception
             UriBuilder uriBuilder = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("uriBuilder", () => builder.ForUri(uriBuilder));
+            Should.Throw<ArgumentNullException>(() => builder.ForUri(uriBuilder), "uriBuilder");
         }
 
         [Fact]
@@ -1070,7 +1070,7 @@ namespace JustEat.HttpClientInterception
                 .Register(builder);
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.PostAsync(options, requestUri.ToString(), content));
 
             // Assert
@@ -1103,7 +1103,7 @@ namespace JustEat.HttpClientInterception
                 .Register(builder);
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.PostAsync(options, requestUri.ToString(), content));
 
             // Assert
@@ -1137,7 +1137,7 @@ namespace JustEat.HttpClientInterception
                 .Register(builder);
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.PostAsync(options, requestUri.ToString(), content));
 
             // Assert
@@ -1309,7 +1309,7 @@ namespace JustEat.HttpClientInterception
             var builder = new HttpRequestInterceptionBuilder();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("options", () => builder.RegisterWith(null));
+            Should.Throw<ArgumentNullException>(() => builder.RegisterWith(null), "options");
         }
 
         [Fact]
@@ -1603,7 +1603,7 @@ namespace JustEat.HttpClientInterception
             using var client = options.CreateHttpClient();
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => client.GetStringAsync("https://public.je-apis.com/consumer/order-history"));
 
             // Assert
@@ -1630,7 +1630,7 @@ namespace JustEat.HttpClientInterception
             client.DefaultRequestHeaders.Add("Accept-Tenant", "ie");
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => client.GetStringAsync("https://public.je-apis.com/consumer/order-history"));
 
             // Assert
@@ -1659,7 +1659,7 @@ namespace JustEat.HttpClientInterception
             client.DefaultRequestHeaders.Add("Accept-Tenant", "uk");
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => client.GetStringAsync("https://public.je-apis.com/consumer/order-history"));
 
             // Assert
@@ -1688,7 +1688,7 @@ namespace JustEat.HttpClientInterception
             client.DefaultRequestHeaders.Add("Authorization", "basic my-other-key");
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => client.GetStringAsync("https://public.je-apis.com/consumer/order-history"));
 
             // Assert
@@ -1704,11 +1704,11 @@ namespace JustEat.HttpClientInterception
             var values = Array.Empty<string>();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("name", () => builder.ForRequestHeader(null, string.Empty));
-            Assert.Throws<ArgumentNullException>("name", () => builder.ForRequestHeader(null, values));
-            Assert.Throws<ArgumentNullException>("name", () => builder.ForRequestHeader(null, (IEnumerable<string>)values));
-            Assert.Throws<ArgumentNullException>("values", () => builder.ForRequestHeader(name, (string[])null));
-            Assert.Throws<ArgumentNullException>("values", () => builder.ForRequestHeader(name, (IEnumerable<string>)null));
+            Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(null, string.Empty), "name");
+            Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(null, values), "name");
+            Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(null, (IEnumerable<string>)values), "name");
+            Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(name, (string[])null), "values");
+            Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(name, (IEnumerable<string>)null), "values");
         }
 
         [Fact]
@@ -1719,7 +1719,7 @@ namespace JustEat.HttpClientInterception
             IDictionary<string, string> headers = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("headers", () => builder.ForRequestHeaders(headers));
+            Should.Throw<ArgumentNullException>(() => builder.ForRequestHeaders(headers), "headers");
         }
 
         [Fact]
@@ -1731,11 +1731,11 @@ namespace JustEat.HttpClientInterception
             var values = Array.Empty<string>();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("name", () => builder.WithContentHeader(null, string.Empty));
-            Assert.Throws<ArgumentNullException>("name", () => builder.WithContentHeader(null, values));
-            Assert.Throws<ArgumentNullException>("name", () => builder.WithContentHeader(null, (IEnumerable<string>)values));
-            Assert.Throws<ArgumentNullException>("values", () => builder.WithContentHeader(name, (string[])null));
-            Assert.Throws<ArgumentNullException>("values", () => builder.WithContentHeader(name, (IEnumerable<string>)null));
+            Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(null, string.Empty), "name");
+            Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(null, values), "name");
+            Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(null, (IEnumerable<string>)values), "name");
+            Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(name, (string[])null), "values");
+            Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(name, (IEnumerable<string>)null), "values");
         }
 
         [Fact]
@@ -1747,8 +1747,8 @@ namespace JustEat.HttpClientInterception
             IDictionary<string, ICollection<string>> headerValues = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("headers", () => builder.WithContentHeaders(headers));
-            Assert.Throws<ArgumentNullException>("headers", () => builder.WithContentHeaders(headerValues));
+            Should.Throw<ArgumentNullException>(() => builder.WithContentHeaders(headers), "headers");
+            Should.Throw<ArgumentNullException>(() => builder.WithContentHeaders(headerValues), "headers");
         }
 
         [Fact]
@@ -1760,11 +1760,11 @@ namespace JustEat.HttpClientInterception
             var values = Array.Empty<string>();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("name", () => builder.WithResponseHeader(null, string.Empty));
-            Assert.Throws<ArgumentNullException>("name", () => builder.WithResponseHeader(null, values));
-            Assert.Throws<ArgumentNullException>("name", () => builder.WithResponseHeader(null, (IEnumerable<string>)values));
-            Assert.Throws<ArgumentNullException>("values", () => builder.WithResponseHeader(name, (string[])null));
-            Assert.Throws<ArgumentNullException>("values", () => builder.WithResponseHeader(name, (IEnumerable<string>)null));
+            Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(null, string.Empty), "name");
+            Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(null, values), "name");
+            Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(null, (IEnumerable<string>)values), "name");
+            Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(name, (string[])null), "values");
+            Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(name, (IEnumerable<string>)null), "values");
         }
 
         [Fact]
@@ -1775,7 +1775,7 @@ namespace JustEat.HttpClientInterception
             IDictionary<string, string> headers = null;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("headers", () => builder.WithResponseHeaders(headers));
+            Should.Throw<ArgumentNullException>(() => builder.WithResponseHeaders(headers), "headers");
         }
 
         [Fact]
@@ -1786,8 +1786,8 @@ namespace JustEat.HttpClientInterception
             var parameters = new Dictionary<string, string>();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).ForFormContent(parameters));
-            Assert.Throws<ArgumentNullException>("parameters", () => builder.ForFormContent(null));
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForFormContent(parameters), "builder");
+            Should.Throw<ArgumentNullException>(() => builder.ForFormContent(null), "parameters");
         }
 
         [Fact]
@@ -1797,7 +1797,7 @@ namespace JustEat.HttpClientInterception
             static bool Predicate(HttpContent content) => false;
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => ((HttpRequestInterceptionBuilder)null).ForContent(Predicate));
+            Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForContent(Predicate), "builder");
         }
 
         [Fact]
@@ -1891,7 +1891,7 @@ namespace JustEat.HttpClientInterception
             using var content = new FormUrlEncodedContent(actualForm);
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
 
             // Assert
@@ -1928,7 +1928,7 @@ namespace JustEat.HttpClientInterception
             using var content = new FormUrlEncodedContent(actualForm);
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
 
             // Assert
@@ -1961,7 +1961,7 @@ namespace JustEat.HttpClientInterception
             using var content = new FormUrlEncodedContent(actualForm);
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
 
             // Assert
@@ -1999,7 +1999,7 @@ namespace JustEat.HttpClientInterception
             using var content = new FormUrlEncodedContent(actualForm);
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
 
             // Assert
@@ -2035,7 +2035,7 @@ namespace JustEat.HttpClientInterception
             using var content = new FormUrlEncodedContent(actualForm);
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/form", content));
 
             // Assert
@@ -2063,7 +2063,7 @@ namespace JustEat.HttpClientInterception
                 .Register(builder);
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.PostAsync(options, "https://test.local/post", new { message = "Hello" }));
 
             // Assert
@@ -2094,7 +2094,7 @@ namespace JustEat.HttpClientInterception
             using var content = new StreamContent(stream);
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => HttpAssert.SendAsync(options, HttpMethod.Post, "https://test.local/post", content));
 
             // Assert
@@ -2256,7 +2256,7 @@ namespace JustEat.HttpClientInterception
             using var client = options.CreateHttpClient();
 
             // Act and Assert
-            await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => client.GetStringAsync("https://google.com/"));
         }
 

--- a/tests/HttpClientInterception.Tests/InterceptingHttpMessageHandlerTests.cs
+++ b/tests/HttpClientInterception.Tests/InterceptingHttpMessageHandlerTests.cs
@@ -23,8 +23,8 @@ namespace JustEat.HttpClientInterception
         public static void Constructor_Throws_If_Options_Is_Null()
         {
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("options", () => new InterceptingHttpMessageHandler(null));
-            Assert.Throws<ArgumentNullException>("options", () => new InterceptingHttpMessageHandler(null, Mock.Of<HttpMessageHandler>()));
+            Should.Throw<ArgumentNullException>(() => new InterceptingHttpMessageHandler(null), "options");
+            Should.Throw<ArgumentNullException>(() => new InterceptingHttpMessageHandler(null, Mock.Of<HttpMessageHandler>()), "options");
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace JustEat.HttpClientInterception
             using var target = options.CreateHttpClient();
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => target.GetAsync("https://google.com/"));
 
             // Assert
@@ -58,7 +58,7 @@ namespace JustEat.HttpClientInterception
             using var content = new StringContent(string.Empty);
 
             // Act
-            var exception = await Assert.ThrowsAsync<HttpRequestNotInterceptedException>(
+            var exception = await Should.ThrowAsync<HttpRequestNotInterceptedException>(
                 () => target.PostAsync("https://google.com/", content));
 
             // Assert


### PR DESCRIPTION
Hi Martin,
Thank you for your great job, I like your work and your idea about implementing a unique version of `HttpClient` for making robust testing.
I used to use `WebApplicationFactory` for testing my APIs which is not comfortable for testing REST API.
In this pull request, I try to implement your testing in a consistent way by using the `Shouldly` library for rewriting asserting of throwing an exception
I wish it is useful for this repo.
