### PR TITLE
Adding Authorization Header

### DIFF
--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -150,7 +150,7 @@ namespace JustEat.HttpClientInterception
                 RequestUri = uri,
             };
 
-            ConfigureMatcherAndDeRegister(interceptor);
+            ConfigureMatcherAndDeregister(interceptor);
 
             return this;
         }

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -179,7 +179,7 @@ namespace JustEat.HttpClientInterception
 
             HttpInterceptionResponse interceptor = builder.Build();
 
-            ConfigureMatcherAndDeRegister(interceptor);
+            ConfigureMatcherAndDeregister(interceptor);
 
             return this;
         }

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -529,7 +529,7 @@ namespace JustEat.HttpClientInterception
             _mappings[key] = registration;
         }
 
-        private void ConfigureMatcherAndDeRegister(HttpInterceptionResponse registration)
+        private void ConfigureMatcherAndDeregister(HttpInterceptionResponse registration)
         {
             ConfigureMatcher(registration);
 

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -150,8 +150,7 @@ namespace JustEat.HttpClientInterception
                 RequestUri = uri,
             };
 
-            string key = BuildKey(interceptor);
-            _mappings.Remove(key);
+            ConfigureMatcherAndDeRegister(interceptor);
 
             return this;
         }
@@ -180,8 +179,7 @@ namespace JustEat.HttpClientInterception
 
             HttpInterceptionResponse interceptor = builder.Build();
 
-            string key = BuildKey(interceptor);
-            _mappings.Remove(key);
+            ConfigureMatcherAndDeRegister(interceptor);
 
             return this;
         }
@@ -507,7 +505,7 @@ namespace JustEat.HttpClientInterception
             return new (false, null);
         }
 
-        private void ConfigureMatcherAndRegister(HttpInterceptionResponse registration)
+        private void ConfigureMatcher(HttpInterceptionResponse registration)
         {
             RequestMatcher matcher;
 
@@ -521,9 +519,22 @@ namespace JustEat.HttpClientInterception
             }
 
             registration.InternalMatcher = matcher;
+        }
+
+        private void ConfigureMatcherAndRegister(HttpInterceptionResponse registration)
+        {
+            ConfigureMatcher(registration);
 
             string key = BuildKey(registration);
             _mappings[key] = registration;
+        }
+
+        private void ConfigureMatcherAndDeRegister(HttpInterceptionResponse registration)
+        {
+            ConfigureMatcher(registration);
+
+            string key = BuildKey(registration);
+            _mappings.Remove(key);
         }
 
         private sealed class OptionsScope : IDisposable

--- a/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -775,6 +776,29 @@ namespace JustEat.HttpClientInterception
         /// </remarks>
         public HttpRequestInterceptionBuilder ForRequestHeader(string name, string value)
             => ForRequestHeader(name, new[] { value });
+
+        /// <summary>
+        /// Sets an Authentication header to intercept a request for.
+        /// </summary>
+        /// <param name="authenticationHeader">The authentication credential of the request.</param>
+        /// <returns>
+        /// The current <see cref="HttpRequestInterceptionBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="authenticationHeader"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        /// HTTP request authentication are only tested for interception if the URI requested was registered for interception.
+        /// </remarks>
+        public HttpRequestInterceptionBuilder ForRequestAuthentication(AuthenticationHeaderValue authenticationHeader)
+        {
+            if (authenticationHeader == null)
+            {
+                throw new ArgumentNullException(nameof(authenticationHeader));
+            }
+
+            return ForRequestHeader("Authorization", new[] { authenticationHeader.ToString() });
+        }
 
         /// <summary>
         /// Sets an HTTP request header to intercept with multiple values.

--- a/src/HttpClientInterception/Matching/DelegatingMatcher.cs
+++ b/src/HttpClientInterception/Matching/DelegatingMatcher.cs
@@ -30,5 +30,11 @@ namespace JustEat.HttpClientInterception.Matching
         /// <inheritdoc />
         public override async Task<bool> IsMatchAsync(HttpRequestMessage request)
             => await _predicate(request).ConfigureAwait(false);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return _predicate.GetHashCode();
+        }
     }
 }

--- a/src/HttpClientInterception/PublicAPI.Shipped.txt
+++ b/src/HttpClientInterception/PublicAPI.Shipped.txt
@@ -33,6 +33,7 @@ JustEat.HttpClientInterception.HttpRequestInterceptionBuilder.ForRequestHeader(s
 JustEat.HttpClientInterception.HttpRequestInterceptionBuilder.ForRequestHeader(string! name, string! value) -> JustEat.HttpClientInterception.HttpRequestInterceptionBuilder!
 JustEat.HttpClientInterception.HttpRequestInterceptionBuilder.ForRequestHeaders(System.Collections.Generic.IDictionary<string!, System.Collections.Generic.ICollection<string!>!>! headers) -> JustEat.HttpClientInterception.HttpRequestInterceptionBuilder!
 JustEat.HttpClientInterception.HttpRequestInterceptionBuilder.ForRequestHeaders(System.Collections.Generic.IDictionary<string!, string!>! headers) -> JustEat.HttpClientInterception.HttpRequestInterceptionBuilder!
+JustEat.HttpClientInterception.HttpRequestInterceptionBuilder.ForRequestAuthentication(System.Net.Http.Headers.AuthenticationHeaderValue! authenticationHeader) -> JustEat.HttpClientInterception.HttpRequestInterceptionBuilder!
 JustEat.HttpClientInterception.HttpRequestInterceptionBuilder.ForScheme(string! scheme) -> JustEat.HttpClientInterception.HttpRequestInterceptionBuilder!
 JustEat.HttpClientInterception.HttpRequestInterceptionBuilder.ForUri(System.Uri! uri) -> JustEat.HttpClientInterception.HttpRequestInterceptionBuilder!
 JustEat.HttpClientInterception.HttpRequestInterceptionBuilder.ForUri(System.UriBuilder! uriBuilder) -> JustEat.HttpClientInterception.HttpRequestInterceptionBuilder!

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
@@ -541,7 +541,7 @@ namespace JustEat.HttpClientInterception
         }
 
         [Fact]
-        public static async Task Deregister_If_Builder_Has_Custom_Matcher()
+        public static async Task Deregister_Works_If_Builder_Has_Custom_Matcher()
         {
             // Arrange
             var builder = new HttpRequestInterceptionBuilder()

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
@@ -541,6 +541,26 @@ namespace JustEat.HttpClientInterception
         }
 
         [Fact]
+        public static async Task Deregister_If_Builder_Has_Custom_Matcher()
+        {
+            // Arrange
+            var builder = new HttpRequestInterceptionBuilder()
+                .Requests().For(async (_) => await Task.FromResult(true));
+
+            var options = new HttpClientInterceptorOptions()
+                .Register(builder);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://www.just-eat.co.uk");
+
+            // Act
+            options.Deregister(builder);
+
+            // Assert
+            var result = await options.GetResponseAsync(request);
+            result.ShouldBeNull();
+        }
+
+        [Fact]
         public static void RegisterByteArray_Throws_If_Method_Is_Null()
         {
             // Arrange

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
@@ -556,8 +556,8 @@ namespace JustEat.HttpClientInterception
             options.Deregister(builder);
 
             // Assert
-            var result = await options.GetResponseAsync(request);
-            result.ShouldBeNull();
+            var actual = await options.GetResponseAsync(request);
+            actual.ShouldBeNull();
         }
 
         [Fact]


### PR DESCRIPTION
Hi Martin,

I am implementing some integration tests with your HTTP client stub for my project and I found it a very useful library that helps me a lot.

I want to test some APIs that need authentication header, first I think it will be interesting to add some fluent extension methods for adding authentication header, like  `.ForRequestAuthentication(basicAuthenticationHeader)`. second I need HttpClientInterceptor to return a different response status code when the authorization header is valid or not.

I read your implementation for matching request header in `RegistrationMatcher`. this method just searches for matching register requests with a proper header, but there is not an easy way to change the founded response status code based on the matching result.

So, I am working to propose a consistent way to adding this feature, for the first step I added a method to `HttpRequestInterceptionBuilder` for adding authorization header, However, I could not change the return status of the response by this way, do you have any suggestion?

I think it should be implemented in a more generalized fashion for changing response status based on different conditions.