### PR TITLE
Fix NullReferenceException when deregistering a builder with a custom matcher

### DIFF
--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -390,7 +390,7 @@ public class HttpClientInterceptorOptions
         if (interceptor.UserMatcher is not null || interceptor.ContentMatcher is not null)
         {
             // Use the internal matcher's hash code as UserMatcher (a delegate)
-            // will always return the hash code. See https://stackoverflow.com/q/6624151/1064169
+            // will always return the same hash code. See https://stackoverflow.com/q/6624151/1064169
             return $"CUSTOM:{interceptor.InternalMatcher!.GetHashCode().ToString(CultureInfo.InvariantCulture)}";
         }
 

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -332,7 +332,7 @@ public class HttpClientInterceptorOptions
         string key = ConfigureMatcherAndRegister(interceptor);
 
         // Store the key so deregistration for the builder works if
-        // if it is not mutated after the registration has occurred.
+        // it is not mutated after the registration has occurred.
         builder.SetMatchKey(key);
 
         return this;

--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -157,6 +157,9 @@ public class HttpClientInterceptorOptions
     /// <exception cref="ArgumentNullException">
     /// <paramref name="builder"/> is <see langword="null"/>.
     /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The HTTP registration associated with <paramref name="builder"/> could not be deregistered.
+    /// </exception>
     /// <remarks>
     /// If <paramref name="builder"/> has been reconfigured since it was used
     /// to register a previous HTTP request interception it will not remove that

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -2145,6 +2145,24 @@ public static class HttpRequestInterceptionBuilderTests
     }
 
     [Fact]
+    public static async Task Builder_Deregisters_With_Custom_Matcher()
+    {
+        // Arrange
+        var builder = new HttpRequestInterceptionBuilder()
+            .Requests().For((_) => Task.FromResult(true));
+
+        var options = new HttpClientInterceptorOptions()
+            .ThrowsOnMissingRegistration()
+            .Register(builder);
+
+        // Act
+        options.Deregister(builder);
+
+        // Assert
+        await Should.ThrowAsync<HttpRequestNotInterceptedException>(() => HttpAssert.GetAsync(options, "https://google.com/"));
+    }
+
+    [Fact]
     public static async Task Builder_For_Posted_Json_To_Match_Intercepts_Request()
     {
         // Arrange

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -2163,6 +2163,35 @@ public static class HttpRequestInterceptionBuilderTests
     }
 
     [Fact]
+    public static void Builder_Deregistration_With_Custom_Matcher_Throws_If_Builder_Mutated()
+    {
+        // Arrange
+        var builder = new HttpRequestInterceptionBuilder()
+            .Requests().For((_) => Task.FromResult(true));
+
+        var options = new HttpClientInterceptorOptions()
+            .Register(builder);
+
+        builder.ForAnyHost();
+
+        // Act and Assert
+        var exception = Should.Throw<InvalidOperationException>(() => options.Deregister(builder));
+        exception.Message.ShouldBe("Failed to deregister HTTP request interception. The builder has not been used to register an HTTP request or has been mutated since it was registered.");
+    }
+
+    [Fact]
+    public static void Builder_Deregistration_Throws_If_Builder_Not_Registered()
+    {
+        // Arrange
+        var builder = new HttpRequestInterceptionBuilder();
+        var options = new HttpClientInterceptorOptions();
+
+        // Act and Assert
+        var exception = Should.Throw<InvalidOperationException>(() => options.Deregister(builder));
+        exception.Message.ShouldBe("Failed to deregister HTTP request interception. The builder has not been used to register an HTTP request or has been mutated since it was registered.");
+    }
+
+    [Fact]
     public static async Task Builder_For_Posted_Json_To_Match_Intercepts_Request()
     {
         // Arrange


### PR DESCRIPTION
Fix `NullReferenceException` deregistering a builder if it used a custom match delegate.

Now it will deregister as long as it hasn't been mutated (otherwise it is "lost" and can't be removed).

If the registration is "lost", then an `InvalidOperationException` is thrown instead to draw the caller's attention to the fact their code is not behaving as expected. Similarly, an exception is now thrown if trying to deregister an HTTP request/builder that was never registered.

Resolves #361.
