### PR TITLE
Bump version to 4.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <VersionPrefix>4.0.1</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' AND '$(GITHUB_HEAD_REF)' != '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>

--- a/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
+++ b/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
@@ -13,10 +13,6 @@
     <SignAssembly>true</SignAssembly>
     <Summary>A .NET library for intercepting server-side HTTP dependencies.</Summary>
     <TargetFrameworks>netstandard2.0;net472;net6.0;net7.0</TargetFrameworks>
-    <!--
-     TODO Remove after 4.0.0 ships to NuGet.org
-    -->
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />


### PR DESCRIPTION
- Bump version for next release.
- Re-enable package baseline validation.
