### PR TITLE
Add GitHub coverage summaries

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,7 @@
 <!--
+
 Summarise the changes this Pull Request makes.
+
 Please include a reference to a GitHub issue if appropriate.
+
 -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,4 +19,16 @@
       <AssemblyMetadata Condition=" $(CommitBranch) != '' " Include="CommitBranch" Value="$(CommitBranch)"  />
     </ItemGroup>
   </Target>
+  <PropertyGroup Condition=" '$(CollectCoverage)' == 'true' ">
+    <ReportGeneratorOutputMarkdown Condition=" '$(ReportGeneratorOutputMarkdown)' == '' AND '$(GITHUB_SHA)' != '' ">true</ReportGeneratorOutputMarkdown>
+    <ReportGeneratorReportTypes>HTML</ReportGeneratorReportTypes>
+    <ReportGeneratorReportTypes Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">$(ReportGeneratorReportTypes);MarkdownSummaryGitHub</ReportGeneratorReportTypes>
+    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(OutputPath), 'coverage'))</ReportGeneratorTargetDirectory>
+    <_MarkdownSummaryPrefix>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;</_MarkdownSummaryPrefix>
+    <_MarkdownSummarySuffix>&lt;/details&gt;</_MarkdownSummarySuffix>
+  </PropertyGroup>
+  <Target Name="GenerateCoverageReports" AfterTargets="GenerateCoverageResultAfterTest" Condition=" '$(CollectCoverage)' == 'true' ">
+    <ReportGenerator ReportFiles="@(CoverletReport)" ReportTypes="$(ReportGeneratorReportTypes)" Tag="$(Version)" TargetDirectory="$(ReportGeneratorTargetDirectory)" Title="$(AssemblyName)" VerbosityLevel="Warning" />
+    <Exec Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' " Command="pwsh -Command %22('$(_MarkdownSummaryPrefix)' + [System.Environment]::NewLine + [System.Environment]::NewLine + (Get-Content $([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md')) | Out-String) + [System.Environment]::NewLine + [System.Environment]::NewLine + '$(_MarkdownSummarySuffix)') >> $(GITHUB_STEP_SUMMARY)%22" />
+  </Target>
 </Project>

--- a/samples/README.md
+++ b/samples/README.md
@@ -9,7 +9,7 @@ This folder contains a sample ASP.NET Core application that uses the `JustEat.Ht
 The application (`/samples/SampleApp`) exposes a single HTTP resource at `GET api/repos`.
 This resource consumes the [GitHub v3 API](https://developer.github.com/v3/) and returns the names of the public repositories belonging to the configured user/organisation as a JSON array of strings. For example:
 
-```
+```json
 [
   "JustBehave",
   "JustSaying",
@@ -18,15 +18,17 @@ This resource consumes the [GitHub v3 API](https://developer.github.com/v3/) and
 ```
 
 To enable use of `JustEat.HttpClientInterception` for testing, the application has a small number of minor changes:
-  1. An [extension method](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp/Extensions/HttpClientExtensions.cs#L18-L28) that registers `HttpClient` for use with [Refit](https://github.com/paulcbetts/refit) to call the GitHub API.
-  1. Dependencies for the GitHub API are [registered](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp/Startup.cs#L24) in the `Startup` class.
-  1. `IGitHub` is injected into the [constructor of `ReposController`](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp/Controllers/ReposController.cs#L18)
+
+1. An [extension method](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp/Extensions/HttpClientExtensions.cs#L18-L28) that registers `HttpClient` for use with [Refit](https://github.com/paulcbetts/refit) to call the GitHub API.
+1. Dependencies for the GitHub API are [registered](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp/Startup.cs#L24) in the `Startup` class.
+1. `IGitHub` is injected into the [constructor of `ReposController`](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp/Controllers/ReposController.cs#L18)
 
 ## Tests
 
 The tests (`/samples/SampleApp.Tests`) self-host the application using [Kestrel](https://github.com/aspnet/KestrelHttpServer) so that the application can be tested in a [black-box](https://en.wikipedia.org/wiki/Black-box_testing) manner by performing HTTP requests against the API's `GET` resource.
 
 This is enabled by:
-  1. An xunit [collection fixture](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/HttpServerCollection.cs#L8-L9) that [self-hosts the server](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/HttpServerFixture.cs#L25-L38) using `WebApplicationFactory<T>`.
-  1. [Creates a shared `HttpClientInterceptorOptions`](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/HttpServerFixture.cs#L20) instance which is [registered](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/HttpServerFixture.cs#L27-L30) to provide a `DelegatingHandler` implementation for use with Dependency Injection via a custom implementation of [`IHttpMessageHandlerBuilderFilter`](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/HttpServerFixture.cs#L40-L65).
-  1. Using `JustEat.HttpClientInterception` to intercept HTTP calls to the GitHub API to [test the API resource](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/ReposTests.cs#L15-L75).
+
+1. An xunit [collection fixture](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/HttpServerCollection.cs#L8-L9) that [self-hosts the server](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/HttpServerFixture.cs#L25-L38) using `WebApplicationFactory<T>`.
+1. [Creates a shared `HttpClientInterceptorOptions`](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/HttpServerFixture.cs#L20) instance which is [registered](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/HttpServerFixture.cs#L27-L30) to provide a `DelegatingHandler` implementation for use with Dependency Injection via a custom implementation of [`IHttpMessageHandlerBuilderFilter`](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/HttpServerFixture.cs#L40-L65).
+1. Using `JustEat.HttpClientInterception` to intercept HTTP calls to the GitHub API to [test the API resource](https://github.com/justeat/httpclient-interception/blob/63e27420c35f66bd4953184586fa10a4762b4bca/samples/SampleApp.Tests/ReposTests.cs#L15-L75).


### PR DESCRIPTION
- Add a code coverage summary to the Actions logs.
- Use the MSBuild version of ReportGenerator.
- Fix some markdown lint warnings.
