### PR TITLE
Remove redundant suppressions

### DIFF
--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Just Eat, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1812
-#pragma warning disable CA1852
-
 using SampleApp.Extensions;
 using SampleApp.Services;
 


### PR DESCRIPTION
Remove now-redundant suppressions for false-positive code analysis warnings.
